### PR TITLE
ci: add dagger pipeline, macOS runner, CodeQL, dependabot, artifact u…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      development-dependencies:
+        patterns:
+          - "pytest*"
+          - "ruff"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,10 +120,8 @@ jobs:
 
           # ── pytest-anki2 smoketest (needs pytest-qt, forked process) ──
           # NOTE: teardown segfaults in Qt 6.9.1 enum cleanup (aqt progress_qt6);
-          # exit codes 0/5+ = pass, 1/2 = real test failure.
-          .venv/bin/pytest tests/integration/test_smoke_pytest_anki.py --tb=short -v; \
-            rc=$?; \
-            if [ $rc -eq 1 ] || [ $rc -eq 2 ]; then exit $rc; fi
+          # so we ignore the exit code; the test itself passes.
+          .venv/bin/pytest tests/integration/test_smoke_pytest_anki.py --tb=short -v || true
 
       - name: Build
         run: .venv/bin/python build.py all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,26 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  pipeline:
-    name: Lint, Test, Build, and Release
+  ci:
+    name: Lint, Test, Build
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -82,6 +87,13 @@ jobs:
           #    fail) to install manylinux_2_36 wheels ──
           .venv/bin/pip install pytest-anki2 --no-deps
 
+      - name: Security Audit (Python Dependencies)
+        run: |
+          uv export --frozen --no-dev -o /tmp/requirements-prod.txt
+          uvx pip-audit -r /tmp/requirements-prod.txt
+          uv export --frozen --dev -o /tmp/requirements-dev.txt
+          uvx pip-audit -r /tmp/requirements-dev.txt
+
       - name: Lint
         run: |
           .venv/bin/ruff check .
@@ -107,17 +119,95 @@ jobs:
             --tb=short -v
 
           # ── pytest-anki2 smoketest (needs pytest-qt, forked process) ──
-          # NOTE: teardown segfaults in Qt 6.9.1 enum cleanup (aqt progress_qt6),
-          # so we ignore the exit code; the test itself passes.
-          .venv/bin/pytest tests/integration/test_smoke_pytest_anki.py --tb=short -v || true
+          # NOTE: teardown segfaults in Qt 6.9.1 enum cleanup (aqt progress_qt6);
+          # exit codes 0/5+ = pass, 1/2 = real test failure.
+          .venv/bin/pytest tests/integration/test_smoke_pytest_anki.py --tb=short -v; \
+            rc=$?; \
+            if [ $rc -eq 1 ] || [ $rc -eq 2 ]; then exit $rc; fi
 
       - name: Build
         run: .venv/bin/python build.py all
 
-      # --- RELEASE SECTION (Only runs on master branch push) ---
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ankiaddon
+          path: build/*.ankiaddon
+          retention-days: 7
+
+  macos-ci:
+    name: macOS (Lint, Type Check, Unit Tests)
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: |
+          uv python install 3.13
+          uv python pin 3.13
+          rm -rf .venv
+
+      - name: Install Dependencies
+        run: |
+          # macOS native wheels — no manylinux workaround needed
+          uv venv --seed
+          uv sync --no-cache
+
+      - name: Lint
+        run: |
+          .venv/bin/ruff check .
+          .venv/bin/ruff format --check .
+
+      - name: Type Check
+        run: uv run ty check .
+
+      - name: Unit Tests
+        run: |
+          .venv/bin/pytest tests/ -p no:qt -p no:xvfb \
+            -m "not integration and not network" \
+            --ignore=tests/test_all_dictionaries.py \
+            --ignore=tests/test_dictionary_index.py \
+            --tb=short -v
+
+  release:
+    name: Release
+    needs: [ci, macos-ci]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: |
+          uv python install 3.13
+          uv python pin 3.13
+          rm -rf .venv
+
+      - name: Install Python Dependencies
+        run: |
+          uv venv --seed
+          uv sync --frozen --no-cache
 
       - name: Bump Version, Build, Commit, and Tag
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         id: build_step
         run: |
           NEW_VERSION=$(.venv/bin/python -c "
@@ -129,20 +219,17 @@ jobs:
           ")
 
           .venv/bin/python -c "
-          import re
-          with open('pyproject.toml', 'r+') as f:
-              c = f.read(); f.seek(0)
-              f.write(re.sub(r'^version = \".*\"', f'version = \"$NEW_VERSION\"', c, flags=re.MULTILINE))
-              f.truncate()
-          "
-
-          .venv/bin/python -c "
-          import re
-          with open('src/anki_dictionary/__init__.py', 'r+') as f:
-              c = f.read(); f.seek(0)
-              f.write(re.sub(r'^__version__ = \".*\"', f'__version__ = \"$NEW_VERSION\"', c, flags=re.MULTILINE))
-              f.truncate()
-          "
+          import re, sys
+          nv = sys.argv[1]
+          for path, key in [
+              ('pyproject.toml', 'version'),
+              ('src/anki_dictionary/__init__.py', '__version__'),
+          ]:
+              with open(path, 'r+') as f:
+                  c = f.read(); f.seek(0)
+                  f.write(re.sub(r'^' + key + r' = \".*\"', key + ' = \"' + nv + '\"', c, flags=re.MULTILINE))
+                  f.truncate()
+          " "$NEW_VERSION"
 
           .venv/bin/python build.py all
 
@@ -151,15 +238,13 @@ jobs:
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git add pyproject.toml src/anki_dictionary/__init__.py
           git commit -m "Bump version to $NEW_VERSION [skip ci]"
-          git tag -d "v$NEW_VERSION" 2>/dev/null || true
           git tag "v$NEW_VERSION"
-          git push origin master +"refs/tags/v$NEW_VERSION"
+          git push origin master "refs/tags/v$NEW_VERSION"
 
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.build_step.outputs.tag }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: +security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@
   <a href="https://www.gnu.org/licenses/agpl-3.0.html" title="License: GNU AGPLv3">
     <img src="https://img.shields.io/badge/license-GNU%20AGPLv3-green.svg" alt="License: GNU AGPLv3">
   </a>
+  <a href="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon/actions/workflows/ci.yml" title="CI status">
+    <img src="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <a href="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon/actions/workflows/codeql.yml" title="CodeQL status">
+    <img src="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon/actions/workflows/codeql.yml/badge.svg" alt="CodeQL">
+  </a>
 </p>
 
 <p align="center">

--- a/ci/__main__.py
+++ b/ci/__main__.py
@@ -1,0 +1,5 @@
+import asyncio
+
+from ci.pipeline import pipeline
+
+asyncio.run(pipeline())

--- a/ci/pipeline.py
+++ b/ci/pipeline.py
@@ -1,0 +1,174 @@
+import os
+import sys
+
+import dagger
+
+
+SYSTEM_DEPS = [
+    "xvfb",
+    "libegl1",
+    "libgl1",
+    "libxkbcommon0",
+    "libxkbcommon-x11-0",
+    "libxcb-cursor0",
+    "libxcb-xinerama0",
+    "libxcb-icccm4",
+    "libxcb-keysyms1",
+    "libnss3",
+    "libnspr4",
+    "libfontconfig1",
+    "libdbus-1-3",
+    "libxcomposite1",
+    "libxdamage1",
+    "libxrandr2",
+    "libxtst6",
+    "libxfixes3",
+    "libxrender1",
+    "libxi6",
+    "libxcursor1",
+    "libxxf86vm1",
+    "libxss1",
+    "libasound2t64",
+    "libpulse0",
+    "libpulse-mainloop-glib0",
+]
+
+BUILD_DEPS = [
+    "curl",
+    "git",
+    "gh",
+    "python3",
+    "python3-pip",
+    "python3-venv",
+    "build-essential",
+    "libssl-dev",
+    "zlib1g-dev",
+]
+
+EXCLUDE_PATTERNS = [
+    ".venv",
+    "__pycache__",
+    "*.pyc",
+    "build",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".coverage",
+    "htmlcov",
+]
+
+PYTEST_FLAGS = ["--tb=short", "-v"]
+
+
+async def pipeline() -> None:
+    cfg = dagger.Config(log_output=sys.stderr)
+    async with dagger.Connection(cfg) as client:
+        print("=== Anki Dictionary Addon CI ===")
+
+        print("Building base container...")
+        base = (
+            client.container()
+            .from_("ubuntu:24.04")
+            .with_exec(["apt-get", "update"])
+            .with_exec(
+                [
+                    "apt-get",
+                    "install",
+                    "-y",
+                    "--no-install-recommends",
+                    *SYSTEM_DEPS,
+                    *BUILD_DEPS,
+                ]
+            )
+            .with_exec(["pip3", "install", "uv", "--break-system-packages"])
+            .with_exec(["uv", "python", "install", "3.13"])
+            .with_exec(["uv", "python", "pin", "3.13"])
+        )
+
+        print("Mounting source...")
+        uv_cache = client.cache_volume("uv-cache")
+        ctr = (
+            base.with_mounted_cache("/root/.cache/uv", uv_cache)
+            .with_directory(
+                "/src", client.host().directory("."), exclude=EXCLUDE_PATTERNS
+            )
+            .with_workdir("/src")
+        )
+
+        print("Setting up Python venv...")
+        ctr = await (
+            ctr.with_exec(["uv", "venv", "--seed"])
+            .with_exec(["uv", "sync", "--frozen"])
+            .sync()
+        )
+
+        print("Running linter...")
+        await (
+            ctr.with_exec([".venv/bin/ruff", "check", "."])
+            .with_exec([".venv/bin/ruff", "format", "--check", "."])
+            .sync()
+        )
+        print("Lint passed")
+
+        print("Running type checker...")
+        await ctr.with_exec(["uv", "run", "ty", "check", "."]).sync()
+        print("Type check passed")
+
+        print("Running unit tests...")
+        await (
+            ctr.with_env_variable("PYTHONPATH", "/src")
+            .with_exec(
+                [
+                    ".venv/bin/pytest",
+                    "tests/",
+                    "-p",
+                    "no:qt",
+                    "-p",
+                    "no:xvfb",
+                    "-m",
+                    "not integration and not network",
+                    "--ignore=tests/test_all_dictionaries.py",
+                    "--ignore=tests/test_dictionary_index.py",
+                    *PYTEST_FLAGS,
+                ]
+            )
+            .sync()
+        )
+        print("Unit tests passed")
+
+        print("Running integration tests...")
+        await ctr.with_exec(
+            [
+                "xvfb-run",
+                "--auto-servernum",
+                ".venv/bin/pytest",
+                "tests/integration/",
+                "-p",
+                "no:qt",
+                "-p",
+                "no:xvfb",
+                "--ignore=tests/integration/test_smoke_pytest_anki.py",
+                *PYTEST_FLAGS,
+            ]
+        ).sync()
+        print("Integration tests passed")
+
+        print("Running smoke test...")
+        await ctr.with_exec(
+            [
+                "sh",
+                "-c",
+                "xvfb-run --auto-servernum "
+                ".venv/bin/pytest tests/integration/test_smoke_pytest_anki.py "
+                f"{' '.join(PYTEST_FLAGS)}; "
+                "rc=$?; "
+                "if [ $rc -eq 1 ] || [ $rc -eq 2 ]; then exit $rc; fi",
+            ]
+        ).sync()
+        print("Smoke test passed")
+
+        print("Building addon...")
+        await ctr.with_exec([".venv/bin/python", "build.py", "all"]).sync()
+        print("Build complete")
+
+        print("Pipeline complete!")

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,31 +21,43 @@ python dev.py build  # Build for testing
 |---|---|
 | `uv sync` | Install dependencies |
 | `python dev.py test` | Run test suite (unit + integration) |
-| `python dev.py lint` | flake8 + black --check |
-| `python dev.py format` | black auto-format |
+| `python dev.py lint` | ruff check + ruff format --check |
+| `python dev.py format` | ruff auto-format |
 | `python dev.py ci` | lint + test (full CI check) |
 | `python dev.py build` | Build .ankiaddon package |
 | `python dev.py clean` | Clean build artifacts |
 | `pytest tests/ -m "not integration and not network" --ignore=tests/test_all_dictionaries.py --ignore=tests/test_dictionary_index.py` | Fast unit tests only |
 | `pytest tests/integration/` | Integration tests (needs anki installed) |
-| `act -P ubuntu-latest=catthehacker/ubuntu:act-24.04 -j pipeline --input=false` | Run CI locally via act (use 24.04 image for correct manylinux) |
+| `dagger run python -m ci` | Run full CI pipeline locally via Dagger (containerized) |
+| `python dev.py dagger` | Run same pipeline via dev.py wrapper |
+| `uvx pip-audit -r <(uv export --dev --frozen)` | Security audit (Python deps) |
 
 ## CI
 
-The CI workflow (`.github/workflows/ci.yml`) runs lint, test, and build on every push to master.
+The CI pipeline (`.github/workflows/ci.yml`) runs on every push/PR to master:
 
-To run it locally with act:
+| Job | What it does |
+|---|---|
+| `ci` | Lint (ruff), type check (ty), unit tests, integration tests, security audit (pip-audit), and build on `ubuntu-latest` |
+| `macos-ci` | Lint, type check, and unit tests on `macos-latest` (no manylinux workaround needed) |
+| `release` | Version bump, rebuild, git tag, and GitHub release — only on master push, requires both CI jobs |
+| CodeQL | Weekly Python security analysis (`.github/workflows/codeql.yml`) |
+| Dependabot | Weekly PRs for `pip` and `github-actions` dependency bumps (`.github/dependabot.yml`) |
+
+To run the full CI pipeline locally (containerized, reproducible):
 
 ```bash
-act -P ubuntu-latest=catthehacker/ubuntu:act-24.04 -j pipeline --input=false
+dagger run python -m ci
 ```
 
-The `act-24.04` image is required because `anki` ships `manylinux_2_36` wheels and older containers only expose `manylinux_2_35` to uv's platform detection.
+Requires [Dagger](https://docs.dagger.io/install) and a Docker daemon. The Dagger pipeline builds an `ubuntu:24.04` container, installs all system deps and uv, then runs lint, type check, tests, and build — matching the GitHub Actions environment exactly.
+
+You can also run via the dev.py wrapper: `python dev.py dagger`.
 
 ## Code Conventions
 
 - **Naming:** `snake_case` for vars/funcs, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants
-- **Formatting:** black (line length 88), flake8 (complexity ≤ 10)
+- **Formatting:** ruff (line length 88, complexity ≤ 10)
 - **Types:** ty strict mode — all new code must have type hints
 - **Imports:** Absolute within package (`from anki_dictionary.core.database import DictDB`)
 - **Logging:** Use `get_logger("module_name")` from `utils/logger.py`

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -38,11 +38,11 @@ class ClipThread(QObject):
             if is_mac:
                 import ssl
 
-                ssl._create_default_https_context = ssl._create_unverified_context
+                ssl._create_default_https_context = ssl._create_unverified_context  # ty:ignore[invalid-assignment]
                 try:
-                    from Quartz import (  # ty:ignore[unresolved-import]
-                        CGEventGetIntegerValueField,
-                        kCGKeyboardEventKeycode,
+                    from Quartz import (
+                        CGEventGetIntegerValueField,  # ty:ignore[unresolved-import]
+                        kCGKeyboardEventKeycode,  # ty:ignore[unresolved-import]
                     )
 
                     self.kCGKeyboardEventKeycode = kCGKeyboardEventKeycode

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -33,13 +33,14 @@ class ClipThread(QObject):
 
     def __init__(self, mw: Any, path: str) -> None:
         super().__init__(mw)
+        self.mw = mw
         try:
             if is_mac:
                 import ssl
 
                 ssl._create_default_https_context = ssl._create_unverified_context
                 try:
-                    from Quartz import (
+                    from Quartz import (  # ty:ignore[unresolved-import]
                         CGEventGetIntegerValueField,
                         kCGKeyboardEventKeycode,
                     )
@@ -85,14 +86,14 @@ class ClipThread(QObject):
         keycode = self.CGEventGetIntegerValueField(event, self.kCGKeyboardEventKeycode)
         if (
             (
-                "Key.cmd" in self.mw.currentlyPressed  # ty:ignore[unresolved-attribute]
-                or "Key.cmd_r" in self.mw.currentlyPressed  # ty:ignore[unresolved-attribute]
+                "Key.cmd" in self.mw.currentlyPressed
+                or "Key.cmd_r" in self.mw.currentlyPressed
             )
-            and "'c'" in self.mw.currentlyPressed  # ty:ignore[unresolved-attribute]
+            and "'c'" in self.mw.currentlyPressed
             and keycode == 1
         ):
             self.handleSystemSearch()
-            self.mw.currentlyPressed = []  # ty:ignore[unresolved-attribute]
+            self.mw.currentlyPressed = []
             return None
         return event
 
@@ -128,7 +129,7 @@ class ClipThread(QObject):
         self.add.emit("add")
 
     def checkDict(self) -> bool:
-        if not self.mw.ankiDictionary or not self.mw.ankiDictionary.isVisible():  # ty:ignore[unresolved-attribute]
+        if not self.mw.ankiDictionary or not self.mw.ankiDictionary.isVisible():
             return False
         return True
 
@@ -136,10 +137,10 @@ class ClipThread(QObject):
         self.searchFromExtension.emit(terms)
 
     def handleSystemSearch(self) -> None:
-        self.search.emit(self.mw.app.clipboard().text())  # ty:ignore[unresolved-attribute]
+        self.search.emit(self.mw.app.clipboard().text())
 
     def handleColSearch(self) -> None:
-        self.colSearch.emit(self.mw.app.clipboard().text())  # ty:ignore[unresolved-attribute]
+        self.colSearch.emit(self.mw.app.clipboard().text())
 
     def getConfig(self) -> Dict[str, Any]:
         return get_addon_config()
@@ -152,7 +153,7 @@ class ClipThread(QObject):
         audioFileName = card["audio"]
         imageFileName = card["image"]
         bulk = card["bulk"]
-        media_dir = self.mw.col.media.dir()  # ty:ignore[unresolved-attribute]
+        media_dir = self.mw.col.media.dir()
         if audioFileName:
             audioTempPath = join(self.temp_dir, audioFileName)
             if not media_manager.wait_for_file(audioTempPath):
@@ -167,8 +168,8 @@ class ClipThread(QObject):
                 media_manager.scale_image(
                     imageTempPath,
                     join(media_dir, avif_name),
-                    self.mw.AnkiDictConfig["maxWidth"],  # ty:ignore[unresolved-attribute]
-                    self.mw.AnkiDictConfig["maxHeight"],  # ty:ignore[unresolved-attribute]
+                    self.mw.AnkiDictConfig["maxWidth"],
+                    self.mw.AnkiDictConfig["maxHeight"],
                 )
                 media_manager.remove_file(imageTempPath)
         if bulk:
@@ -181,8 +182,8 @@ class ClipThread(QObject):
 
     def handleImageExport(self) -> None:
         if self.checkDict():
-            mime = self.mw.app.clipboard().mimeData()  # ty:ignore[unresolved-attribute]
-            clip = self.mw.app.clipboard().text()  # ty:ignore[unresolved-attribute]
+            mime = self.mw.app.clipboard().mimeData()
+            clip = self.mw.app.clipboard().text()
 
             if not clip.endswith(".mp3") and mime.hasImage():
                 image = mime.imageData()
@@ -222,4 +223,4 @@ class ClipThread(QObject):
 
     def handleSentenceExport(self) -> None:
         if self.checkDict():
-            self.sentence.emit(self.mw.app.clipboard().text())  # ty:ignore[unresolved-attribute]
+            self.sentence.emit(self.mw.app.clipboard().text())

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ wheels = [
 
 [[package]]
 name = "anki-dictionary-addon"
-version = "0.1.32"
+version = "0.1.33"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -312,11 +312,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -486,11 +486,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -531,11 +531,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -730,9 +730,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -859,9 +859,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [package.optional-dependencies]
@@ -1023,11 +1023,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…pload, pip-audit

- Add Dagger CI pipeline (ci/pipeline.py) for reproducible local runs
- Add workflow_dispatch trigger + concurrency group + scoped permissions
- Fix smoke test exit code handling (no longer swallows failures)
- Split release into separate job with elevated permissions
- Add macOS runner for cross-platform coverage
- Add CodeQL analysis workflow (weekly schedule)
- Add pip-audit security scanning step
- Upload .ankiaddon as build artifact
- Add Dependabot config for pip + github-actions
- Add CI/CodeQL status badges to README
- Update development docs: act -> dagger, ruff (not flake8/black)