### PR TITLE
Refactor release workflow with Dagger CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,22 @@
+# CI — Runs on PRs and pushes to master.
+#
+# Trigger strategy:
+#   - pull_request → verify PRs before merge
+#   - push → catch direct pushes and produce build artifacts for release
+#   - [skip ci] in commit message skips this workflow (GitHub-native)
+#
+# Linux CI uses Dagger (ci/pipeline.py) for reproducibility with local runs.
+# macOS CI runs natively for macOS-specific verification.
+# Build artifacts from the push-on-master run are uploaded for the release
+# workflow to download (avoids rebuilding in release).
+
 name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   workflow_dispatch:
 
 concurrency:
@@ -15,19 +27,19 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    name: Lint, Test, Build
-    runs-on: ubuntu-latest
+  linux-ci:
+    name: Linux (Dagger — Lint, Type Check, Test, Build)
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -37,97 +49,16 @@ jobs:
           uv python pin 3.13
           rm -rf .venv
 
-      - name: Install System Dependencies
+      - name: Install Dagger CLI
         run: |
-          sudo apt-get update && sudo apt-get install -y \
-            xvfb \
-            libegl1 libgl1 \
-            libxkbcommon0 libxkbcommon-x11-0 \
-            libxcb-cursor0 libxcb-xinerama0 libxcb-icccm4 libxcb-keysyms1 \
-            libnss3 libnspr4 \
-            libfontconfig1 libdbus-1-3 \
-            libxcomposite1 libxdamage1 libxrandr2 libxtst6 \
-            libxfixes3 libxrender1 libxi6 libxcursor1 \
-            libxxf86vm1 libxss1 \
-            libasound2t64 libpulse0 libpulse-mainloop-glib0
+          curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Install Python Dependencies
-        run: |
-          # ── Project deps via uv (none need manylinux_2_36) ──
-          uv venv --seed
-          uv sync --frozen --no-dev --no-cache
-
-          # ── Dev deps + anki/aqt transitive deps via pip ──
-          # (all pure Python or manylinux_2_35 compatible)
-          .venv/bin/pip install \
-            decorator distro markdown orjson protobuf PySocks \
-            flask jsonschema pip-system-certs send2trash waitress \
-            "ruff>=0.11.0" \
-            "pytest>=8.4.1" "pytest-cov>=6.1.1" "pytest-qt>=4.4.0" \
-            "pytest-xdist>=3.6.1" "pytest-xvfb>=3.1.0"
-
-          # ── anki/aqt: extract wheels directly into site-packages to
-          #    bypass platform tag checks (catthehacker containers have
-          #    compatible glibc but pip rejects manylinux_2_36 wheels) ──
-          .venv/bin/python -c "
-          import io, os, urllib.request, zipfile
-          site_pkgs = [p for p in __import__('sys').path if 'site-packages' in p][0]
-          for name, url in [
-              ('anki', 'https://files.pythonhosted.org/packages/2b/bc/36972ebb0c09effa41a1dc5f1e9c19b9fd85675cc3196f43559eeb3d0ceb/anki-25.9.4-cp39-abi3-manylinux_2_36_x86_64.whl'),
-              ('aqt',  'https://files.pythonhosted.org/packages/83/a1/a8e8c5bc7dda44c0decfdeb128ca308d65d7beca1a4131230e9abadef439/aqt-25.9.4-py3-none-any.whl'),
-          ]:
-              resp = urllib.request.urlopen(url)
-              zf = zipfile.ZipFile(io.BytesIO(resp.read()))
-              zf.extractall(site_pkgs)
-              print(f'Extracted {name} to {site_pkgs}')
-          "
-
-          # ── pytest-anki2: install without deps because anki/aqt are
-          #    already extracted above and we don't want pip to try (and
-          #    fail) to install manylinux_2_36 wheels ──
-          .venv/bin/pip install pytest-anki2 --no-deps
-
-      - name: Security Audit (Python Dependencies)
-        run: |
-          uv export --frozen --no-dev -o /tmp/requirements-prod.txt
-          uvx pip-audit -r /tmp/requirements-prod.txt
-          uv export --frozen --dev -o /tmp/requirements-dev.txt
-          uvx pip-audit -r /tmp/requirements-dev.txt
-
-      - name: Lint
-        run: |
-          .venv/bin/ruff check .
-          .venv/bin/ruff format --check .
-
-      - name: Type Check
-        run: |
-          uv sync --frozen
-          uv run ty check .
-
-      - name: Test
-        run: |
-          # ── Fast unit tests (no Qt, no network) ──
-          .venv/bin/pytest tests/ -p no:qt -p no:xvfb \
-            -m "not integration and not network" \
-            --ignore=tests/test_all_dictionaries.py \
-            --ignore=tests/test_dictionary_index.py \
-            --tb=short -v
-
-          # ── Existing integration tests (custom qapp, no pytest-qt) ──
-          .venv/bin/pytest tests/integration/ -p no:qt -p no:xvfb \
-            --ignore=tests/integration/test_smoke_pytest_anki.py \
-            --tb=short -v
-
-          # ── pytest-anki2 smoketest (needs pytest-qt, forked process) ──
-          # NOTE: teardown segfaults in Qt 6.9.1 enum cleanup (aqt progress_qt6);
-          # so we ignore the exit code; the test itself passes.
-          .venv/bin/pytest tests/integration/test_smoke_pytest_anki.py --tb=short -v || true
-
-      - name: Build
-        run: .venv/bin/python build.py all
+      - name: Run CI Pipeline (Dagger)
+        run: dagger run uv run python -m ci
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ankiaddon
           path: build/*.ankiaddon
@@ -139,12 +70,12 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -175,5 +106,3 @@ jobs:
             --ignore=tests/test_all_dictionaries.py \
             --ignore=tests/test_dictionary_index.py \
             --tb=short -v
-
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,54 @@
+# Release — Creates a GitHub Release on merged PRs to master.
+#
+# Trigger strategy:
+#   - pull_request closed + merged → automatic release (tests already passed in CI)
+#   - workflow_dispatch → manual release with optional version override
+#   - Does NOT trigger on direct pushes to master (only PR merges)
+#
+# This workflow does NOT re-run tests — it trusts that CI passed on the PR.
+# It only: computes version → bumps files → builds → tags → creates release.
+#
+# Version source of truth: git tags (NOT pyproject.toml).
+# This prevents version mismatches if a previous release failed mid-way.
+
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  pull_request:
+    types: [closed]
     branches: [master]
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.2.3). Leave empty for auto-increment from latest tag."
+        required: false
+        type: string
 
 concurrency:
   group: release
   cancel-in-progress: false
 
+# Minimal permissions — only what's needed to push tags, commits, and releases
 permissions:
   contents: write
 
 jobs:
   release:
     name: Bump, Build, and Release
+    # Only run on merged PRs (not just closed) or manual dispatch
     if: >
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
-
-      - name: Check for [skip ci]
-        if: github.event_name == 'workflow_run'
-        run: |
-          if echo "${{ github.event.workflow_run.head_commit.message }}" | grep -q '\[skip ci\]'; then
-            echo "Commit contains [skip ci] — skipping release"
-            exit 0
-          fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -53,40 +63,94 @@ jobs:
           uv venv --seed
           uv sync --frozen --no-dev --no-cache
 
-      - name: Git Auth & Rebase (pull concurrent pushes)
-        run: |
-          git remote set-url origin \
-            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git fetch origin master
-          git rebase origin/master || {
-            echo "❌ Rebase failed — aborting to avoid force-push"
-            git rebase --abort
-            exit 1
-          }
-
-      - name: Bump Version, Build, Commit, and Tag
-        id: build_step
+      # ── Compute version ──
+      # Source of truth: latest git tag. Falls back to pyproject.toml if no tags.
+      # Manual override via workflow_dispatch inputs.version takes precedence.
+      - name: Compute Next Version
+        id: version
         shell: bash
         run: |
           set -euo pipefail
 
-          # ── Compute next version ──
-          NEW_VERSION=$(uv run python -c "
+          MANUAL="${{ github.event.inputs.version || '' }}"
+
+          if [ -n "$MANUAL" ]; then
+            # ── Validate manual version format (semantic versioning) ──
+            if ! echo "$MANUAL" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$'; then
+              echo "❌ Invalid version format: '$MANUAL'"
+              echo "   Expected: X.Y.Z or X.Y.Z-suffix (e.g. 1.2.3 or 1.2.3-beta)"
+              exit 1
+            fi
+            echo "version=$MANUAL" >> "$GITHUB_OUTPUT"
+            echo "📌 Using manual version: $MANUAL"
+            exit 0
+          fi
+
+          # ── Auto-increment from latest git tag ──
+          LATEST_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+
+          if [ -z "$LATEST_TAG" ]; then
+            # ── Fallback: no tags exist, read from pyproject.toml ──
+            echo "⚠️  No version tags found — falling back to pyproject.toml"
+            CURRENT=$(uv run python -c "
           import tomllib
           with open('pyproject.toml', 'rb') as f:
               v = tomllib.load(f)['project']['version'].split('.')
           v[-1] = str(int(v[-1]) + 1)
           print('.'.join(v))
           ")
+            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+            echo "📌 Computed version from pyproject.toml: $CURRENT"
+          else
+            # ── Parse and increment patch version ──
+            V="${LATEST_TAG#v}"
+            IFS='.' read -ra PARTS <<< "$V"
 
-          # ── Guard against tag collision ──
-          if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
-            echo "⚠️  Tag v$NEW_VERSION already exists — skipping (release already published)"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            if [ "${#PARTS[@]}" -lt 3 ]; then
+              echo "❌ Failed to parse version from tag '$LATEST_TAG' — expected X.Y.Z"
+              exit 1
+            fi
+
+            PATCH=$((PARTS[2] + 1))
+            NEW_VERSION="${PARTS[0]}.${PARTS[1]}.$PATCH"
+            echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+            echo "📌 Latest tag: $LATEST_TAG → Next version: $NEW_VERSION"
           fi
 
-          # ── Bump version in source files ──
+      # ── Guard: check if tag/release already exists (idempotency) ──
+      # If tag exists + release exists → skip entirely (already released)
+      # If tag exists + no release → recreate release (recovery from partial failure)
+      # If tag doesn't exist → proceed with full release
+      - name: Check for Existing Tag or Release
+        id: guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${{ steps.version.outputs.version }}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+            HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG")
+
+            if [ "$HTTP_STATUS" = "200" ]; then
+              echo "⚠️  Tag $TAG and release already exist — nothing to do"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "⚠️  Tag $TAG exists but no release — will recreate release"
+              echo "recreate=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "✅ Tag $TAG does not exist — proceeding with full release"
+          fi
+
+      # ── Bump version in source files (only for new releases) ──
+      - name: Bump Version in Source Files
+        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
+        shell: bash
+        run: |
+          V="${{ steps.version.outputs.version }}"
           uv run python -c "
           import re, sys
           nv = sys.argv[1]
@@ -98,30 +162,46 @@ jobs:
                   c = f.read(); f.seek(0)
                   f.write(re.sub(r'^' + key + r' = \".*\"', key + ' = \"' + nv + '\"', c, flags=re.MULTILINE))
                   f.truncate()
-          " "$NEW_VERSION"
+              print(f'  Bumped {key} to {nv} in {path}')
+          " "$V"
 
-          # ── Build the addon ──
-          uv run python build.py all
+      # ── Build the addon ──
+      # Always builds fresh — the version in the .ankiaddon filename must match.
+      - name: Build Addon
+        if: steps.guard.outputs.skip != 'true'
+        run: uv run python build.py all
 
-          # ── Commit and tag ──
+      # ── Git auth + rebase (handle concurrent merges) ──
+      - name: Git Auth & Rebase
+        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
+        run: |
+          git remote set-url origin \
+            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git fetch origin master
+          git rebase origin/master || {
+            echo "❌ Rebase failed — aborting to avoid force-push"
+            git rebase --abort
+            exit 1
+          }
+
+      # ── Commit version bump, create tag, push both ──
+      - name: Commit, Tag, and Push
+        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml src/anki_dictionary/__init__.py
-          git commit -m "Bump version to $NEW_VERSION [skip ci]"
+          git commit -m "Bump version to ${{ steps.version.outputs.version }} [skip ci]"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin master "refs/tags/v${{ steps.version.outputs.version }}"
 
-          # ── Push branch and tag atomically ──
-          git tag "v$NEW_VERSION"
-          git push origin master "refs/tags/v$NEW_VERSION"
-
-          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Create Release
-        if: steps.build_step.outputs.skip != 'true'
-        uses: softprops/action-gh-release@v2
+      # ── Create GitHub Release with auto-generated notes ──
+      - name: Create GitHub Release
+        if: steps.guard.outputs.skip != 'true'
+        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 # v3.0.1
         with:
-          tag_name: ${{ steps.build_step.outputs.tag }}
-          name: Release ${{ steps.build_step.outputs.tag }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
           files: build/*.ankiaddon
           generate_release_notes: true
         env:

--- a/ci/pipeline.py
+++ b/ci/pipeline.py
@@ -169,7 +169,11 @@ async def pipeline() -> None:
         print("Smoke test passed")
 
         print("Building addon...")
-        await ctr.with_exec([".venv/bin/python", "build.py", "all"]).sync()
+        built = await ctr.with_exec([".venv/bin/python", "build.py", "all"]).sync()
         print("Build complete")
+
+        print("Exporting build artifacts to host...")
+        await built.directory("/src/build").export("./build")
+        print("Artifacts exported to ./build/")
 
         print("Pipeline complete!")


### PR DESCRIPTION
## Summary

Refactors the CI and release workflows to use Dagger for the Linux CI pipeline, and simplifies the release workflow to pure release logic.

### Changes

**ci/pipeline.py**
- Added build artifact export at end of pipeline (`.export(\"./build\")`)

**ci.yml**
- Linux CI now runs via `dagger run uv run python -m ci` instead of duplicating all setup logic
- All actions pinned to commit SHAs
- macOS CI kept as-is (Dagger uses Linux container)

**release.yml**
- Now a pure release workflow (no tests — trusts CI)
- Version derived from git tags (source of truth), not pyproject.toml
- Manual version override via `workflow_dispatch` inputs with semver validation
- Idempotent: skips if tag+release exists, recreates if tag exists without release
- All actions pinned to commit SHAs
- Concurrency group prevents overlapping releases

### Notes

- The release tag (`v0.1.34`) will be auto-created when this PR is merged and the release workflow runs.
- Linux CI now runs in a reproducible container via Dagger — same as `dagger run python -m ci` locally.