### PR TITLE
Fix: move rebase before file modifications in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,20 @@ jobs:
             echo "✅ Tag $TAG does not exist — proceeding with full release"
           fi
 
+      # ── Git auth + rebase (handle concurrent merges) ──
+      # Must run BEFORE any file modifications to avoid "unstaged changes" error.
+      - name: Git Auth & Rebase
+        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
+        run: |
+          git remote set-url origin \
+            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git fetch origin master
+          git rebase origin/master || {
+            echo "❌ Rebase failed — aborting to avoid force-push"
+            git rebase --abort
+            exit 1
+          }
+
       # ── Bump version in source files (only for new releases) ──
       - name: Bump Version in Source Files
         if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
@@ -170,19 +184,6 @@ jobs:
       - name: Build Addon
         if: steps.guard.outputs.skip != 'true'
         run: uv run python build.py all
-
-      # ── Git auth + rebase (handle concurrent merges) ──
-      - name: Git Auth & Rebase
-        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
-        run: |
-          git remote set-url origin \
-            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git fetch origin master
-          git rebase origin/master || {
-            echo "❌ Rebase failed — aborting to avoid force-push"
-            git rebase --abort
-            exit 1
-          }
 
       # ── Commit version bump, create tag, push both ──
       - name: Commit, Tag, and Push


### PR DESCRIPTION
## Bug

The `Git Auth & Rebase` step ran after the version bump and build, causing:

> error: cannot rebase: You have unstaged changes.

The version bump modifies `pyproject.toml` and `__init__.py` (unstaged), which blocks rebase.

## Fix

Moved `Git Auth & Rebase` to before any file modifications. New order:

1. Compute version from tags
2. Guard: check existing tag/release
3. **Git Auth & Rebase** ← now here, clean working tree
4. Bump version in source files
5. Build addon
6. Commit, tag, push
7. Create GitHub Release