### PR TITLE
Fix: handle branch protection when pushing version bump commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,9 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         run: uv run python build.py all
 
-      # ── Commit version bump, create tag, push both ──
+      # ── Commit version bump, create tag, push ──
+      # Master push may be rejected by branch protection (requires PRs).
+      # The tag push is the critical part — the release works with just the tag.
       - name: Commit, Tag, and Push
         if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.recreate != 'true'
         run: |
@@ -194,7 +196,8 @@ jobs:
           git add pyproject.toml src/anki_dictionary/__init__.py
           git commit -m "Bump version to ${{ steps.version.outputs.version }} [skip ci]"
           git tag "v${{ steps.version.outputs.version }}"
-          git push origin master "refs/tags/v${{ steps.version.outputs.version }}"
+          git push origin master || echo "⚠️  Commit push to master rejected (protected branch) — tag push will follow"
+          git push origin "refs/tags/v${{ steps.version.outputs.version }}"
 
       # ── Create GitHub Release with auto-generated notes ──
       - name: Create GitHub Release


### PR DESCRIPTION
## Problem

The release workflow pushes the version bump commit directly to master, but the repository has a branch protection rule:

> Changes must be made through a pull request.

This causes `git push origin master ...` to be rejected, which fails the whole step.

Meanwhile, the tag push (`git push origin refs/tags/vX.Y.Z`) succeeds — tags are not protected.

## Fix

- Separate master push and tag push into two commands
- Allow master push to fail gracefully (`|| echo ...`)
- Tag always gets pushed, which is all the release needs
- Version bump commit exists locally as a marker