### PR TITLE
fix: LLM Connection Error no longer triggers Anki warning dialog

### DIFF
--- a/src/anki_dictionary/core/search/pipeline.py
+++ b/src/anki_dictionary/core/search/pipeline.py
@@ -313,15 +313,20 @@ class SearchPipeline:
             'font-size: 1.1em;">LLM Connection Error</div>'
             f"<div>{error_msg}</div></div>"
         )
-        self.midict.eval(
-            f"var loader = document.getElementById('{id_name}'); "
-            f"if(loader) {{ "
-            f"  var old = loader.querySelector('.definitionBlock'); "
-            f"  if(old) old.remove(); "
-            f"  var tb = loader.querySelector('.dictionaryTitleBlock'); "
-            f"  if(tb) tb.insertAdjacentHTML('afterend', {esc}); "
-            f"}}"
-        )
+        try:
+            self.midict.eval(
+                f"var loader = document.getElementById('{id_name}'); "
+                f"if(loader) {{ "
+                f"  var old = loader.querySelector('.definitionBlock'); "
+                f"  if(old) old.remove(); "
+                f"  var tb = loader.querySelector('.dictionaryTitleBlock'); "
+                f"  if(tb) tb.insertAdjacentHTML('afterend', {esc}); "
+                f"}}"
+            )
+        except Exception:
+            logger.debug(
+                "Failed to inject LLM error into webview (may have been destroyed)"
+            )
 
     # ── Forvo result injection ─────────────────────
 

--- a/src/anki_dictionary/ui/settings/llm_settings_tab.py
+++ b/src/anki_dictionary/ui/settings/llm_settings_tab.py
@@ -15,9 +15,6 @@ from aqt.qt import (
     QVBoxLayout,
     QWidget,
 )
-from aqt.utils import showInfo
-
-from ...utils.common import miInfo
 
 
 class _PromptRow(QWidget):
@@ -294,14 +291,12 @@ class LLMSettingsTab(QWidget):
             message = result["message"]
 
             if success:
-                self.llmStatusLabel.setText("Success!")
+                self.llmStatusLabel.setText(message)
                 self.llmStatusLabel.setStyleSheet("color: green; font-weight: bold;")
-                showInfo(message, self)
             else:
-                self.llmStatusLabel.setText("Failed!")
+                self.llmStatusLabel.setText(message)
                 self.llmStatusLabel.setStyleSheet("color: red; font-weight: bold;")
-                miInfo(message, self)
         except Exception as e:
-            self.llmStatusLabel.setText("Error!")
+            msg = f"Test crashed with error: {str(e)}"
+            self.llmStatusLabel.setText(msg)
             self.llmStatusLabel.setStyleSheet("color: red; font-weight: bold;")
-            miInfo(f"Test crashed with error: {str(e)}", self)


### PR DESCRIPTION
- Removed redundant miInfo/showInfo dialogs from settings test handler (status label already displays the result clearly)
- Wrapped midict.eval in showLLMError in try/except to prevent stale webview exceptions from reaching Anki's global error handler