### PR TITLE
Add LICENSE, expand ruff linting, add coverage tracking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@
 #   - [skip ci] in commit message skips this workflow (GitHub-native)
 #
 # Linux CI uses Dagger (ci/pipeline.py) for reproducibility with local runs.
-# macOS CI runs natively for macOS-specific verification.
 # Build artifacts from the push-on-master run are uploaded for the release
 # workflow to download (avoids rebuilding in release).
 
@@ -63,47 +62,3 @@ jobs:
           name: ankiaddon
           path: build/*.ankiaddon
           retention-days: 7
-
-  macos-ci:
-    name: macOS (Lint, Type Check, Unit Tests)
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: macos-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          fetch-depth: 0
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-
-      - name: Install Python 3.13
-        run: |
-          uv python install 3.13
-          uv python pin 3.13
-          rm -rf .venv
-
-      - name: Install Dependencies
-        run: |
-          # macOS native wheels — no manylinux workaround needed
-          uv venv --seed
-          uv sync --no-cache
-
-      - name: Lint
-        run: |
-          .venv/bin/ruff check .
-          .venv/bin/ruff format --check .
-
-      - name: Type Check
-        run: uv run ty check .
-
-      - name: Unit Tests
-        run: |
-          .venv/bin/pytest tests/ -p no:qt -p no:xvfb \
-            -m "not integration and not network" \
-            --ignore=tests/test_all_dictionaries.py \
-            --ignore=tests/test_dictionary_index.py \
-            --cov=src/ --cov-report=term-missing --cov-fail-under=0 \
-            --tb=short -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,4 +105,5 @@ jobs:
             -m "not integration and not network" \
             --ignore=tests/test_all_dictionaries.py \
             --ignore=tests/test_dictionary_index.py \
+            --cov=src/ --cov-report=term-missing --cov-fail-under=0 \
             --tb=short -v

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or actions, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://ankiweb.net/shared/info/1973740182">
     <img src="https://img.shields.io/badge/AnkiWeb-1973740182-blue.svg" alt="AnkiWeb ID">
   </a>
-  <a href="https://www.gnu.org/licenses/agpl-3.0.html" title="License: GNU AGPLv3">
+  <a href="LICENSE" title="License: GNU AGPLv3">
     <img src="https://img.shields.io/badge/license-GNU%20AGPLv3-green.svg" alt="License: GNU AGPLv3">
   </a>
   <a href="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon/actions/workflows/ci.yml" title="CI status">
@@ -68,7 +68,7 @@ This addon is the modern successor to the [Migaku Dictionary Addon](https://gith
 
 The **Anki Dictionary Addon** is a successor to the [Migaku Dictionary Addon](https://github.com/migaku-official/Migaku-Dictionary-Addon).
 
-This project is **free and open-source software**. The code is released under the **GNU AGPLv3 license**. Please see the [LICENSE](https://www.gnu.org/licenses/agpl-3.0.html) file for details.
+This project is **free and open-source software**. The code is released under the **GNU AGPLv3 license**. Please see the [LICENSE](LICENSE) file for details.
 
 -----
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Anki Dictionary Addon
 
@@ -7,9 +6,9 @@ allowing users to search dictionaries and automatically create cards.
 """
 
 import os
-import sys
 import ssl
-from typing import Any, Dict, List, Optional
+import sys
+from typing import Any
 
 try:
     from aqt import mw
@@ -46,8 +45,7 @@ if vendor_path not in sys.path:
 # Special check for broken PIL in vendor (often happens if bundled on different OS)
 if os.path.exists(os.path.join(vendor_path, "PIL")):
     try:
-        # If we can't import a basic PIL component from vendor, it might be broken
-        import PIL
+        import PIL  # noqa: F401
     except ImportError:
         # If it's broken, remove vendor from path temporarily or handle it
         pass
@@ -63,7 +61,7 @@ class AddonState:
     """Container for addon state."""
 
     def __init__(self) -> None:
-        self.config: Dict[str, Any] = {}
+        self.config: dict[str, Any] = {}
         self.exporting_definitions: bool = False
         self.settings_open: bool = False
         self.dictionary_instance: Any = (
@@ -71,12 +69,12 @@ class AddonState:
         )
         self.editor_loaded_after_dictionary: bool = False
         self.bulk_media_export_cancelled: bool = False
-        self.currently_pressed: List[str] = []
+        self.currently_pressed: list[str] = []
         self.dict_db: Any = None  # Will be properly typed when we fix the DictDB class
 
 
 # Global state instance
-_addon_state: Optional[AddonState] = None
+_addon_state: AddonState | None = None
 _initialized = False
 
 
@@ -153,7 +151,7 @@ def initialize_addon() -> None:
 
     # Setup hooks and UI
     try:
-        from anki_dictionary.core.hooks import setup_hooks, setup_gui_menu
+        from anki_dictionary.core.hooks import setup_gui_menu, setup_hooks
         from anki_dictionary.utils.config import refresh_anki_dict_config
 
         # Make refresh function globally available (legacy compatibility)

--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ if vendor_path not in sys.path:
 # Special check for broken PIL in vendor (often happens if bundled on different OS)
 if os.path.exists(os.path.join(vendor_path, "PIL")):
     try:
-        import PIL  # noqa: F401
+        __import__("PIL")
     except ImportError:
         # If it's broken, remove vendor from path temporarily or handle it
         pass

--- a/build.py
+++ b/build.py
@@ -6,12 +6,12 @@ This script helps build and package the addon for distribution.
 It handles dependency installation and file bundling.
 """
 
-import os
-import sys
-import shutil
-import zipfile
 import json
+import os
+import shutil
 import subprocess
+import sys
+import zipfile
 from pathlib import Path
 
 
@@ -28,7 +28,7 @@ def get_project_config():
             # Fallback to toml library
             import toml
 
-            with open("pyproject.toml", "r") as f:
+            with open("pyproject.toml") as f:
                 config = toml.load(f)
 
         return config
@@ -49,7 +49,7 @@ def run_pip_command(args, env=None):
         # We need to map some flags because uv pip is stricter than pip
         mapped_args = []
         skip_next = False
-        for i, arg in enumerate(args):
+        for _i, arg in enumerate(args):
             if skip_next:
                 skip_next = False
                 continue
@@ -219,17 +219,11 @@ def generate_manifest():
     """Generate manifest.json from pyproject.toml data"""
     project_config = get_project_config()["project"]
 
-    # Extract macOS-specific requirements for manifest
+    # macOS-specific requirements (extracted for manifest)
     dependencies = project_config.get("dependencies", [])
-    macos_requirements = []
 
     for dep in dependencies:
         if "pyobjc" in dep and "darwin" in dep:
-            # Extract package name before semicolon
-            package_name = dep.split(";")[0].strip()
-            # macos_requirements.append(package_name)
-            # Actually, manifest 'requirements' are usually not used by Anki for pip install?
-            # Anki checks this list to warn users?
             pass
 
     manifest_data = {
@@ -244,7 +238,7 @@ def generate_manifest():
     with open(manifest_path, "w") as f:
         json.dump(manifest_data, f, indent=4)
 
-    print(f"   ✓ Generated manifest.json")
+    print("   ✓ Generated manifest.json")
     return manifest_path
 
 
@@ -289,7 +283,7 @@ def build_addon():
     config_path = addon_dir / "config.json"
     if config_path.exists():
         print("   🧹 Cleaning configuration in build...")
-        with open(config_path, "r", encoding="utf-8") as f:
+        with open(config_path, encoding="utf-8") as f:
             config = json.load(f)
 
         # Reset to defaults

--- a/ci/pipeline.py
+++ b/ci/pipeline.py
@@ -1,8 +1,6 @@
-import os
 import sys
 
 import dagger
-
 
 SYSTEM_DEPS = [
     "xvfb",
@@ -121,6 +119,9 @@ async def pipeline() -> None:
                 [
                     ".venv/bin/pytest",
                     "tests/",
+                    "--cov=src/",
+                    "--cov-report=term-missing",
+                    "--cov-fail-under=0",
                     "-p",
                     "no:qt",
                     "-p",

--- a/dev.py
+++ b/dev.py
@@ -5,9 +5,9 @@ Development helper script for Anki Dictionary Addon
 This script provides common development tasks in one place.
 """
 
+import os
 import subprocess
 import sys
-import os
 from pathlib import Path
 
 
@@ -23,6 +23,9 @@ def run_tests():
         "run",
         "pytest",
         "tests/",
+        "--cov=src/",
+        "--cov-report=term-missing",
+        "--cov-fail-under=0",
         "-p",
         "no:qt",
         "-p",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ target-version = "py313"
 exclude = ["_check_tags.py"]
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["F", "I", "B", "UP"]
 ignore = ["E501"]
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ quote-style = "double"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["E402"]
+"src/anki_dictionary/core/clip_thread.py" = ["B010"]
 
 [tool.ty]
 

--- a/scripts/create_empty_db.py
+++ b/scripts/create_empty_db.py
@@ -5,8 +5,8 @@ Database initialization script for Anki Dictionary Addon
 This script creates a new empty database with the required schema for the addon.
 """
 
-import sqlite3
 import os
+import sqlite3
 import sys
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,9 +9,9 @@ This script helps automate the release process:
 4. GitHub Actions will then build and create the release automatically
 """
 
+import re
 import subprocess
 import sys
-import re
 from pathlib import Path
 
 
@@ -28,7 +28,7 @@ def get_current_version():
             # Fallback to toml library
             import toml
 
-            with open("pyproject.toml", "r") as f:
+            with open("pyproject.toml") as f:
                 config = toml.load(f)
 
         return config["project"]["version"]
@@ -43,7 +43,7 @@ def update_version(new_version):
 
     # 1. Update pyproject.toml
     try:
-        with open("pyproject.toml", "r") as f:
+        with open("pyproject.toml") as f:
             content = f.read()
         pattern = r'version\s*=\s*["\'][^"\']*["\']'
         replacement = f'version = "{new_version}"'
@@ -59,7 +59,7 @@ def update_version(new_version):
     init_path = Path("src/anki_dictionary/__init__.py")
     if init_path.exists():
         try:
-            with open(init_path, "r") as f:
+            with open(init_path) as f:
                 content = f.read()
             pattern = r'__version__\s*=\s*["\'][^"\']*["\']'
             replacement = f'__version__ = "{new_version}"'
@@ -222,10 +222,10 @@ def main():
     # Confirm with user
     print("\nThis will:")
     print(f"  • Update version in pyproject.toml to {new_version}")
-    print(f"  • Commit the change")
+    print("  • Commit the change")
     print(f"  • Create tag v{new_version}")
-    print(f"  • Push to remote repository")
-    print(f"  • Trigger GitHub Actions to build and release")
+    print("  • Push to remote repository")
+    print("  • Trigger GitHub Actions to build and release")
     print()
 
     confirm = input("Continue with release? (y/N): ")

--- a/src/anki_dictionary/core/card_handler.py
+++ b/src/anki_dictionary/core/card_handler.py
@@ -1,19 +1,27 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import json
 import os
 from os.path import join
-from typing import List, Tuple, Any, Union
+from typing import Any
 
-from aqt.qt import QImage, QMimeData, QPixmap, QSize, QUrl, Qt, QLabel, QWidget
-from aqt.qt import QHBoxLayout, QVBoxLayout
-from aqt.utils import tooltip
 from aqt.operations.note import update_note
+from aqt.qt import (
+    QHBoxLayout,
+    QLabel,
+    QMimeData,
+    QPixmap,
+    QSize,
+    Qt,
+    QUrl,
+    QVBoxLayout,
+    QWidget,
+)
+from aqt.utils import tooltip
 
-from ..utils.logger import get_logger
-from ..utils import media_manager
 from ..exporters.card_exporter import CardExporter
+from ..utils import media_manager
+from ..utils.logger import get_logger
 
 logger = get_logger(__name__.split(".")[-1])
 
@@ -24,11 +32,11 @@ class CardCreationHandler:
     def __init__(self, midict):
         self.midict = midict
 
-    def addImgsToExportWindow(self, word: str, urls: List[str]) -> None:
+    def addImgsToExportWindow(self, word: str, urls: list[str]) -> None:
         self.initCardExporterIfNeeded()
         img_separator = ""
-        imgs: List[str] = []
-        raw_paths: List[str] = []
+        imgs: list[str] = []
+        raw_paths: list[str] = []
         auto_convert = self.midict.config.get("imageAutoConvert", True)
         media_dir = self.midict.dictInt.mw.col.media.dir()
         for imgurl in urls:
@@ -92,7 +100,7 @@ class CardCreationHandler:
         except Exception as e:
             logger.error(f"Error copying images to clipboard: {e}")
 
-    def getThumbs(self, paths: List[str]) -> QWidget:
+    def getThumbs(self, paths: list[str]) -> QWidget:
         thumbCase = QWidget()
         thumbCase.setContentsMargins(0, 0, 0, 0)
         vLayout = QVBoxLayout()
@@ -122,7 +130,7 @@ class CardCreationHandler:
         self.initCardExporterIfNeeded()
         self.midict.addWindow.addDefinition(dictName, word, text)
 
-    def exportImage(self, pathAndName: Tuple[str, str]) -> None:
+    def exportImage(self, pathAndName: tuple[str, str]) -> None:
         self.midict.dictInt.ensureVisible()
         path, name = pathAndName
         self.initCardExporterIfNeeded()
@@ -133,7 +141,7 @@ class CardCreationHandler:
         if not self.midict.addWindow:
             self.midict.addWindow = CardExporter(self.midict.dictInt, self.midict)
 
-    def bulkTextExport(self, cards: List[Any]) -> None:
+    def bulkTextExport(self, cards: list[Any]) -> None:
         self.initCardExporterIfNeeded()
         self.midict.addWindow.bulkTextExport(cards)
 
@@ -145,7 +153,7 @@ class CardCreationHandler:
         if self.midict.addWindow:
             self.midict.addWindow.bulkMediaExportCancelledByBrowserRefresh()
 
-    def exportAudio(self, audioList: Tuple[str, str, str]) -> None:
+    def exportAudio(self, audioList: tuple[str, str, str]) -> None:
         self.midict.dictInt.ensureVisible()
         temp, tag, name = audioList
         self.initCardExporterIfNeeded()
@@ -170,7 +178,7 @@ class CardCreationHandler:
 
     def getFieldContent(
         self, fContent: str, definition: str, addType: str
-    ) -> Union[str, bool]:
+    ) -> str | bool:
         fieldText = False
         if addType == "overwrite":
             fieldText = definition
@@ -188,7 +196,7 @@ class CardCreationHandler:
         if (self.midict.reviewer and self.midict.reviewer.card) or (
             self.midict.currentEditor and self.midict.currentEditor.note
         ):
-            urls_list: List[str] = []
+            urls_list: list[str] = []
             img_separator = ""
             urls_data = json.loads(urls)
             auto_convert = self.midict.config.get("imageAutoConvert", True)

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -40,7 +40,7 @@ class ClipThread(QObject):
                     ssl, "_create_default_https_context", ssl._create_unverified_context
                 )
                 try:
-                    from Quartz import (
+                    from Quartz import (  # ty:ignore[unresolved-import]
                         CGEventGetIntegerValueField,
                         kCGKeyboardEventKeycode,
                     )

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -1,13 +1,11 @@
 import os
 import re
 import sys
-import time
-from os.path import join, exists, dirname
-from typing import Any, Dict
+from os.path import dirname, join
+from typing import Any
 
-from aqt.qt import QObject, QSize, Qt
-from aqt.qt import pyqtSignal
-from anki.utils import is_mac, is_win, is_lin
+from anki.utils import is_lin, is_mac, is_win
+from aqt.qt import QObject, QSize, Qt, pyqtSignal
 
 from ..utils import media_manager
 from ..utils.config import get_addon_config
@@ -142,14 +140,13 @@ class ClipThread(QObject):
     def handleColSearch(self) -> None:
         self.colSearch.emit(self.mw.app.clipboard().text())
 
-    def getConfig(self) -> Dict[str, Any]:
+    def getConfig(self) -> dict[str, Any]:
         return get_addon_config()
 
     def handleBulkTextExport(self, cards: list) -> None:
         self.bulkTextExport.emit(cards)
 
     def handleExtensionCardExport(self, card: dict) -> None:
-        config = self.getConfig()
         audioFileName = card["audio"]
         imageFileName = card["image"]
         bulk = card["bulk"]

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -36,11 +36,11 @@ class ClipThread(QObject):
             if is_mac:
                 import ssl
 
-                ssl._create_default_https_context = ssl._create_unverified_context  # ty:ignore[invalid-assignment]
+                ssl._create_default_https_context = ssl._create_unverified_context
                 try:
                     from Quartz import (
-                        CGEventGetIntegerValueField,  # ty:ignore[unresolved-import]
-                        kCGKeyboardEventKeycode,  # ty:ignore[unresolved-import]
+                        CGEventGetIntegerValueField,
+                        kCGKeyboardEventKeycode,
                     )
 
                     self.kCGKeyboardEventKeycode = kCGKeyboardEventKeycode

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -40,7 +40,7 @@ class ClipThread(QObject):
                     ssl, "_create_default_https_context", ssl._create_unverified_context
                 )
                 try:
-                    from Quartz import (  # ty:ignore[unresolved-import]
+                    from Quartz import (
                         CGEventGetIntegerValueField,
                         kCGKeyboardEventKeycode,
                     )

--- a/src/anki_dictionary/core/clip_thread.py
+++ b/src/anki_dictionary/core/clip_thread.py
@@ -36,7 +36,9 @@ class ClipThread(QObject):
             if is_mac:
                 import ssl
 
-                ssl._create_default_https_context = ssl._create_unverified_context
+                setattr(
+                    ssl, "_create_default_https_context", ssl._create_unverified_context
+                )
                 try:
                     from Quartz import (
                         CGEventGetIntegerValueField,

--- a/src/anki_dictionary/core/database.py
+++ b/src/anki_dictionary/core/database.py
@@ -1,23 +1,22 @@
-# -*- coding: utf-8 -*-
-
-import sqlite3
+import json
 import os
 import re
-import json
-from typing import Any, Dict, List, Optional, Tuple
+import sqlite3
+from typing import Any
 
 from aqt import mw
+
+from ..utils.common import miInfo
+from ..utils.config import get_addon_config
+from ..utils.logger import get_logger
 from ..utils.paths import (
+    get_addon_name,
     get_addon_root,
     get_db_dir,
-    get_addon_name,
 )
-from ..utils.common import miInfo
-from ..utils.logger import get_logger
-from ..utils.config import get_addon_config
+from .frequency import FrequencyEngine
 from .search.query import SearchQueryBuilder
 from .word_list_registry import WordListRegistry
-from .frequency import FrequencyEngine
 
 # Initialize logger
 logger = get_logger("database")
@@ -28,12 +27,12 @@ class DictDB:
 
     def __init__(self) -> None:
         """Initialize the database connection."""
-        self.conn: Optional[sqlite3.Connection] = None
-        self.c: Optional[sqlite3.Cursor] = None
-        self.oldConnection: Optional[sqlite3.Cursor] = None
-        self._extra_data_cache: Dict[str, List[Any]] = {}
-        self._registry: Optional[WordListRegistry] = None
-        self._frequency_engine: Optional[FrequencyEngine] = None
+        self.conn: sqlite3.Connection | None = None
+        self.c: sqlite3.Cursor | None = None
+        self.oldConnection: sqlite3.Cursor | None = None
+        self._extra_data_cache: dict[str, list[Any]] = {}
+        self._registry: WordListRegistry | None = None
+        self._frequency_engine: FrequencyEngine | None = None
         self.search_query_builder = SearchQueryBuilder(self)
 
         # Get the root addon directory
@@ -99,7 +98,7 @@ class DictDB:
         if self.conn:
             self.conn.close()
 
-    def _get_extra_data(self, lang: str) -> List[Any]:
+    def _get_extra_data(self, lang: str) -> list[Any]:
         """Load all frequency and level data for a language via WordListRegistry."""
         if lang in self._extra_data_cache:
             return self._extra_data_cache[lang]
@@ -122,9 +121,9 @@ class DictDB:
 
     def _apply_frequency_info(
         self,
-        entry: Dict[str, Any],
-        providers: List[Any],
-        config: Dict[str, Any],
+        entry: dict[str, Any],
+        providers: list[Any],
+        config: dict[str, Any],
     ) -> None:
         if self._frequency_engine is not None:
             self._frequency_engine.apply(entry, providers, config)
@@ -139,7 +138,7 @@ class DictDB:
 
         return adjust_reading(reading)
 
-    def getLangId(self, lang: str) -> Optional[int]:
+    def getLangId(self, lang: str) -> int | None:
         """Get language ID from language name."""
         if not self._ensure_connection():
             return None
@@ -170,7 +169,7 @@ class DictDB:
         self.commitChanges()
         cursor.execute("VACUUM;")
 
-    def getLangIdFromDict(self, dictname: str) -> Optional[int]:
+    def getLangIdFromDict(self, dictname: str) -> int | None:
         """Get language ID for a given dictionary name."""
         if not self._ensure_connection():
             return None
@@ -181,7 +180,7 @@ class DictDB:
         result = cursor.fetchone()
         return result[0] if result else None
 
-    def getDictsByLanguage(self, lang: str) -> List[str]:
+    def getDictsByLanguage(self, lang: str) -> list[str]:
         """Get all dictionary names for a given language."""
         if not self._ensure_connection():
             return []
@@ -189,7 +188,7 @@ class DictDB:
         cursor = self._get_cursor()
         cursor.execute("SELECT dictname FROM dictnames WHERE lid = ?;", (lid,))
         try:
-            langs: List[str] = []
+            langs: list[str] = []
             allLs = cursor.fetchall()
             if len(allLs) > 0:
                 for l in allLs:
@@ -215,7 +214,7 @@ class DictDB:
 
     def addDict(
         self, dictname: str, lang: str, termHeader: str
-    ) -> Tuple[bool, str, Optional[str]]:
+    ) -> tuple[bool, str, str | None]:
         """Add a new dictionary to the database."""
         if not self._ensure_connection():
             return False, "Database connection failed", None
@@ -312,7 +311,7 @@ class DictDB:
 
         return result if result else "unnamed_dictionary"
 
-    def formatDictName(self, lid: Optional[int], name: str) -> str:
+    def formatDictName(self, lid: int | None, name: str) -> str:
         """Format dictionary name with language ID prefix."""
         return "l" + str(lid) + "name" + name
 
@@ -326,7 +325,7 @@ class DictDB:
         self.commitChanges()
         cursor.execute("VACUUM;")
 
-    def addLanguages(self, list: List[str]) -> None:
+    def addLanguages(self, list: list[str]) -> None:
         """Add multiple languages to the database."""
         if not self._ensure_connection():
             return
@@ -335,14 +334,14 @@ class DictDB:
             cursor.execute("INSERT INTO langnames (langname) VALUES (?);", (l,))
         self.commitChanges()
 
-    def getCurrentDbLangs(self) -> List[str]:
+    def getCurrentDbLangs(self) -> list[str]:
         """Get all languages currently in the database."""
         if not self._ensure_connection():
             return []
         cursor = self._get_cursor()
         cursor.execute("SELECT langname FROM langnames;")
         try:
-            langs: List[str] = []
+            langs: list[str] = []
             allLs = cursor.fetchall()
             if len(allLs) > 0:
                 for l in allLs:
@@ -351,10 +350,10 @@ class DictDB:
         except Exception:
             return []
 
-    def getUserGroups(self, dicts: List[str]) -> List[Dict[str, str]]:
+    def getUserGroups(self, dicts: list[str]) -> list[dict[str, str]]:
         """Get user dictionary groups based on provided dictionary names."""
         currentDicts = self.getDictToTable()
-        foundDicts: List[Dict[str, str]] = []
+        foundDicts: list[dict[str, str]] = []
         for d in dicts:
             # Check for both raw table name and clean name
             if d in currentDicts:
@@ -373,7 +372,7 @@ class DictDB:
                     foundDicts.append(currentDicts[clean_d])
         return foundDicts
 
-    def getDictToTable(self) -> Dict[str, Dict[str, str]]:
+    def getDictToTable(self) -> dict[str, dict[str, str]]:
         """Get dictionary to table mapping."""
         if not self._ensure_connection():
             return {}
@@ -382,7 +381,7 @@ class DictDB:
             "SELECT dictname, lid, langname FROM dictnames INNER JOIN langnames ON langnames.id = dictnames.lid;"
         )
         try:
-            dicts: Dict[str, Dict[str, str]] = {}
+            dicts: dict[str, dict[str, str]] = {}
             allDs = cursor.fetchall()
             if len(allDs) > 0:
                 for d in allDs:
@@ -402,14 +401,14 @@ class DictDB:
         except:
             return {}
 
-    def fetchDefs(self) -> List[str]:
+    def fetchDefs(self) -> list[str]:
         """Fetch definitions from dictname table."""
         if not self._ensure_connection():
             return []
         cursor = self._get_cursor()
         cursor.execute("SELECT definition FROM dictname LIMIT 10;")
         try:
-            langs: List[str] = []
+            langs: list[str] = []
             allLs = cursor.fetchall()
             if len(allLs) > 0:
                 for l in allLs:
@@ -418,14 +417,14 @@ class DictDB:
         except Exception:
             return []
 
-    def getAllDicts(self) -> List[str]:
+    def getAllDicts(self) -> list[str]:
         """Get all dictionary names formatted with language prefix."""
         if not self._ensure_connection():
             return []
         cursor = self._get_cursor()
         cursor.execute("SELECT dictname, lid FROM dictnames;")
         try:
-            dicts: List[str] = []
+            dicts: list[str] = []
             allDs = cursor.fetchall()
             if len(allDs) > 0:
                 for d in allDs:
@@ -434,7 +433,7 @@ class DictDB:
         except Exception:
             return []
 
-    def getAllDictsWithLang(self) -> List[Dict[str, str]]:
+    def getAllDictsWithLang(self) -> list[dict[str, str]]:
         """Get all dictionaries with their languages."""
         if not self._ensure_connection():
             return []
@@ -443,7 +442,7 @@ class DictDB:
             "SELECT dictname, lid, langname FROM dictnames INNER JOIN langnames ON langnames.id = dictnames.lid;"
         )
         try:
-            dicts: List[Dict[str, str]] = []
+            dicts: list[dict[str, str]] = []
             allDs = cursor.fetchall()
             if len(allDs) > 0:
                 for d in allDs:
@@ -454,10 +453,10 @@ class DictDB:
         except Exception:
             return []
 
-    def getDefaultGroups(self) -> Dict[str, Dict[str, Any]]:
+    def getDefaultGroups(self) -> dict[str, dict[str, Any]]:
         """Get default dictionary groups by language."""
         langs = self.getCurrentDbLangs()
-        dictsByLang: Dict[str, Dict[str, Any]] = {}
+        dictsByLang: dict[str, dict[str, Any]] = {}
         cursor = self._get_cursor()
         for lang in langs:
             cursor.execute(
@@ -465,7 +464,7 @@ class DictDB:
                 (lang,),
             )
             allDs = cursor.fetchall()
-            dicts: Dict[str, Any] = {}
+            dicts: dict[str, Any] = {}
             dicts["customFont"] = False
             dicts["font"] = False
             dicts["dictionaries"] = []
@@ -482,7 +481,7 @@ class DictDB:
         """Clean language ID prefix from dictionary name."""
         return re.sub(r"l\d+name", "", name)
 
-    def getDuplicateSetting(self, name: str) -> Optional[Tuple[int, List[str]]]:
+    def getDuplicateSetting(self, name: str) -> tuple[int, list[str]] | None:
         """Get duplicate setting for a dictionary."""
         if not self._ensure_connection():
             return None
@@ -502,8 +501,8 @@ class DictDB:
             return None
 
     def get_term_frequency_info(
-        self, term: str, lang: str, config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, term: str, lang: str, config: dict[str, Any]
+    ) -> dict[str, Any]:
         return self.search_query_builder.get_term_frequency_info(term, lang, config)
 
     def searchTerm(
@@ -564,7 +563,7 @@ class DictDB:
         )
 
     def importToDict(
-        self, dictName: str, dictionaryData: List[Tuple[Any, ...]]
+        self, dictName: str, dictionaryData: list[tuple[Any, ...]]
     ) -> None:
         """Import dictionary data to specified dictionary table."""
         if not self._ensure_connection():
@@ -617,7 +616,7 @@ class DictDB:
         )
         self.commitChanges()
 
-    def getFieldsSetting(self, name: str) -> Optional[Dict[str, Any]]:
+    def getFieldsSetting(self, name: str) -> dict[str, Any] | None:
         """Get fields setting for a dictionary."""
         if not self._ensure_connection():
             return None
@@ -637,9 +636,7 @@ class DictDB:
         except Exception:
             return None
 
-    def getAddTypeAndFields(
-        self, dictName: str
-    ) -> Optional[Tuple[Dict[str, Any], str]]:
+    def getAddTypeAndFields(self, dictName: str) -> tuple[dict[str, Any], str] | None:
         """Get add type and fields for a dictionary."""
         if not self._ensure_connection():
             return None
@@ -658,7 +655,7 @@ class DictDB:
         except Exception:
             return None
 
-    def getDupHeaders(self) -> Optional[Dict[str, int]]:
+    def getDupHeaders(self) -> dict[str, int] | None:
         """Get duplicate headers for all dictionaries."""
         if not self._ensure_connection():
             return None
@@ -666,7 +663,7 @@ class DictDB:
         cursor.execute("SELECT dictname, duplicateHeader FROM dictnames")
         try:
             dictHeaders = cursor.fetchall()
-            results: Dict[str, int] = {}
+            results: dict[str, int] = {}
             for r in dictHeaders:
                 results[r[0]] = r[1]
             return results
@@ -685,7 +682,7 @@ class DictDB:
         )
         self.commitChanges()
 
-    def getTermHeaders(self) -> Optional[Dict[str, List[str]]]:
+    def getTermHeaders(self) -> dict[str, list[str]] | None:
         """Get term headers for all dictionaries."""
         if not self._ensure_connection():
             return None
@@ -693,14 +690,14 @@ class DictDB:
         cursor.execute("SELECT dictname, termHeader FROM dictnames")
         try:
             dictHeaders = cursor.fetchall()
-            results: Dict[str, List[str]] = {}
+            results: dict[str, list[str]] = {}
             for r in dictHeaders:
                 results[r[0]] = json.loads(r[1])
             return results
         except Exception:
             return None
 
-    def getAddType(self, name: str) -> Optional[str]:
+    def getAddType(self, name: str) -> str | None:
         """Get add type for a dictionary."""
         if not self._ensure_connection():
             return None
@@ -713,7 +710,7 @@ class DictDB:
         result = cursor.fetchone()
         return result[0] if result else None
 
-    def getDictTermHeader(self, dictname: str) -> Optional[str]:
+    def getDictTermHeader(self, dictname: str) -> str | None:
         """Get term header for a specific dictionary."""
         if not self._ensure_connection():
             return None

--- a/src/anki_dictionary/core/dictionary.py
+++ b/src/anki_dictionary/core/dictionary.py
@@ -7,6 +7,7 @@ from os.path import dirname, exists, join
 
 from anki.utils import is_mac
 from aqt.qt import (
+    QColor,  # noqa: F401 — needed at runtime by downstream importers
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -16,6 +17,7 @@ from aqt.qt import (
     QLabel,
     QLineEdit,
     QPalette,
+    QPixmap,  # noqa: F401 — needed at runtime by downstream importers
     QPushButton,
     QShortcut,
     QSize,

--- a/src/anki_dictionary/core/dictionary.py
+++ b/src/anki_dictionary/core/dictionary.py
@@ -1,21 +1,12 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from aqt.utils import (
-    shortcut,
-    saveGeom,
-    saveSplitter,
-    showInfo,
-    askUser,
-    ensureWidgetInScreenBoundaries,
-)
 import json
-import sys
-import math
-import base64
-from anki.hooks import runHook
+import os
+import re
+from os.path import dirname, exists, join
+
+from anki.utils import is_mac
 from aqt.qt import (
-    QColor,
     QComboBox,
     QFrame,
     QHBoxLayout,
@@ -24,55 +15,37 @@ from aqt.qt import (
     QKeySequence,
     QLabel,
     QLineEdit,
-    QMimeData,
     QPalette,
-    QPixmap,
     QPushButton,
     QShortcut,
     QSize,
+    Qt,
     QVBoxLayout,
     QWidget,
-    Qt,
     pyqtSignal,
 )
-from PyQt6.QtCore import QThreadPool, QUrl
-from aqt.utils import openLink, tooltip
-from anki.utils import is_mac, is_win, is_lin
-from anki.lang import _
+from aqt.utils import (
+    ensureWidgetInScreenBoundaries,
+)
 from aqt.webview import AnkiWebView
-import re
-from shutil import copyfile
-import os, shutil
-from os.path import join, exists, dirname
-from typing import List, Dict, Optional, Tuple, Any, Union
-from urllib.request import Request, urlopen
+from PyQt6.QtCore import QThreadPool, QUrl
 
 from ..utils.history import HistoryBrowser, HistoryModel
-from aqt.editor import Editor
-from aqt.operations.note import update_note
-from ..exporters.card_exporter import CardExporter
-import time
-from . import database as dictdb
 from ..utils.logger import get_logger
-from .search.pipeline import SearchPipeline
 from .card_handler import CardCreationHandler
+from .search.pipeline import SearchPipeline
 
 logger = get_logger(__name__.split(".")[-1])
 
-import aqt
-from ..integrations import image_search as duckduckgoimages
-from ..integrations import llm as llm_integration
-from ..integrations import forvo as forvo_integration
-from ..ui.settings.settings_gui import SettingsGui
-import datetime
 import codecs
-import ntpath
-from ..utils.common import miInfo
-from ..web.icons import get_base64_icon
+import datetime
+
 from PyQt6.QtSvgWidgets import QSvgWidget
-from ..ui.dialogs.theme_editor import *
+
 from ..ui import theme_controller
-from ..ui.themes import *
+from ..ui.dialogs.theme_editor import ThemeEditorDialog
+from ..ui.settings.settings_gui import SettingsGui
+from ..ui.themes import ThemeManager
 
 
 class MIDict(AnkiWebView):
@@ -254,7 +227,7 @@ def imageResizer(img_path):
 
 class DictInterface(QWidget):
     def __init__(self, dictdb, mw, path, welcome, parent=None, terms=False):
-        super(DictInterface, self).__init__()
+        super().__init__()
         self.db = dictdb
         self.verticalBar = False
         self.addonPath = path
@@ -278,7 +251,6 @@ class DictInterface(QWidget):
 
     def refresh_application_theme(self, reload_html=True):
         self.theme_manager._load_active_theme()
-        active_theme_dict = theme_controller.get_theme_dict(self.theme_manager)
         self.setStyleSheet(self.theme_manager.get_qt_styles())
         theme_controller.apply_child_widget_styles(self, self.theme_manager)
         self.setAllIcons()
@@ -443,7 +415,7 @@ class DictInterface(QWidget):
         js_path = join(self.addonPath, "assets", "scripts", "dictionary.js")
 
         # Read the JavaScript content to inline it
-        with open(js_path, "r", encoding="utf-8") as js_file:
+        with open(js_path, encoding="utf-8") as js_file:
             js_content = js_file.read()
 
         # Get saved font sizes from config, default to [12, 22]
@@ -451,7 +423,7 @@ class DictInterface(QWidget):
         fefs = font_sizes[0] if len(font_sizes) > 0 else 12
         dbfs = font_sizes[1] if len(font_sizes) > 1 else 22
 
-        with open(html_path, "r", encoding="utf-8") as fh:
+        with open(html_path, encoding="utf-8") as fh:
             html = fh.read()
             # Inject font size variables before the main script
             font_size_init = f"<script>var fefs = {fefs}, dbfs = {dbfs};</script>"
@@ -464,7 +436,6 @@ class DictInterface(QWidget):
             html = html.replace('<style id="customThemeCss"></style>', custom_theme_css)
             # Always inject welcome screen content if available
             if self.welcome and self.welcome.strip():
-                escaped_welcome = json.dumps(self.welcome)
                 html = html.replace(
                     '<div id="welcomeBackground"></div>',
                     f'<div id="welcomeBackground">{self.welcome}</div>',
@@ -498,7 +469,7 @@ class DictInterface(QWidget):
 
     def getInsertHTMLJS(self):
         insertHTML = join(self.addonPath, "assets", "scripts", "insertHTML.js")
-        with open(insertHTML, "r", encoding="utf-8") as insertHTMLFile:
+        with open(insertHTML, encoding="utf-8") as insertHTMLFile:
             return insertHTMLFile.read()
 
     def focusWindow(self):
@@ -1039,7 +1010,7 @@ class DictInterface(QWidget):
         path = join(self.mw.col.media.dir(), "_searchHistory.json")
         try:
             if exists(path):
-                with open(path, "r", encoding="utf-8") as histFile:
+                with open(path, encoding="utf-8") as histFile:
                     return json.loads(histFile.read())
             else:
                 # Create empty search history file if it doesn't exist
@@ -1226,7 +1197,7 @@ class SVGPushButton(QPushButton):
 
         # Read SVG file and replace color placeholders with the theme color
         try:
-            with open(svgPath, "r", encoding="utf-8") as f:
+            with open(svgPath, encoding="utf-8") as f:
                 svg_data = f.read()
                 svg_data = svg_data.replace('fill="currentColor"', f'fill="{color}"')
                 svg_data = svg_data.replace(

--- a/src/anki_dictionary/core/frequency.py
+++ b/src/anki_dictionary/core/frequency.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
-from ..utils.config import get_addon_config
 from ..utils.logger import get_logger
-from ..utils.paths import get_db_dir
 from .word_list_registry import WordListProvider, WordListRegistry
 
 logger = get_logger(__name__.split(".")[-1])
@@ -27,8 +25,8 @@ KATAKANA = (
 
 _HIRA_ORDS = [ord(c) for c in HIRAGANA]
 _KATA_ORDS = [ord(c) for c in KATAKANA]
-_HIRAGANA_TABLE = dict(zip(_KATA_ORDS, HIRAGANA))
-_KATAKANA_TABLE = dict(zip(_HIRA_ORDS, KATAKANA))
+_HIRAGANA_TABLE = dict(zip(_KATA_ORDS, HIRAGANA, strict=True))
+_KATAKANA_TABLE = dict(zip(_HIRA_ORDS, KATAKANA, strict=True))
 
 
 def kana_converter(to_translate: str, hiraganer: bool = False) -> str:
@@ -43,7 +41,7 @@ def adjust_reading(reading: str) -> str:
 
 
 def get_star_count(
-    freq: int, star_char: str = "\u2605", thresholds: Optional[List[int]] = None
+    freq: int, star_char: str = "\u2605", thresholds: list[int] | None = None
 ) -> str:
     """Convert frequency rank to star rating string."""
     if thresholds is None:
@@ -74,13 +72,13 @@ class FrequencyEngine:
     To test with fake providers, pass a list of WordListProvider directly.
     """
 
-    def __init__(self, registry: Optional[WordListRegistry] = None) -> None:
+    def __init__(self, registry: WordListRegistry | None = None) -> None:
         self._registry = registry
 
     # ── public ─────────────────────────────────────
 
     @staticmethod
-    def _get_display_name(name: str, display_names: Dict[str, str]) -> str:
+    def _get_display_name(name: str, display_names: dict[str, str]) -> str:
         cfg = display_names.get(name)
         if cfg:
             return cfg
@@ -94,8 +92,8 @@ class FrequencyEngine:
     @staticmethod
     def _get_provider_role(
         provider: WordListProvider,
-        provider_roles: Dict[str, str],
-        word_list_visibility: Dict[str, Dict[str, bool]],
+        provider_roles: dict[str, str],
+        word_list_visibility: dict[str, dict[str, bool]],
     ) -> str:
         """Resolve the role for *provider*.
 
@@ -118,9 +116,9 @@ class FrequencyEngine:
 
     def apply(
         self,
-        entry: Dict[str, Any],
-        providers: List[WordListProvider],
-        config: Dict[str, Any],
+        entry: dict[str, Any],
+        providers: list[WordListProvider],
+        config: dict[str, Any],
     ) -> None:
         """Mutate *entry* in-place with starCount, frequency, levelLabels."""
         if not providers:
@@ -133,8 +131,8 @@ class FrequencyEngine:
         word_list_display_names = config.get("word_list_display_names", {})
         provider_roles = config.get("provider_roles", {})
 
-        levels: List[str] = []
-        frequency: Optional[int] = None
+        levels: list[str] = []
+        frequency: int | None = None
         term = entry["term"]
         alt = entry.get("altterm", "")
         entry_reading = adjust_reading(entry.get("pronunciation", "") or term)
@@ -196,7 +194,7 @@ class FrequencyEngine:
             entry["starCount"] = ""
             entry.pop("frequency", None)
 
-    def get_providers_for_lang(self, lang: str) -> List[WordListProvider]:
+    def get_providers_for_lang(self, lang: str) -> list[WordListProvider]:
         if self._registry is None:
             return []
         return self._registry.get_providers(lang)

--- a/src/anki_dictionary/core/hooks.py
+++ b/src/anki_dictionary/core/hooks.py
@@ -12,12 +12,10 @@ import re
 
 try:
     from anki.hooks import addHook, wrap
-    from anki.utils import is_lin, is_mac, is_win
 except ImportError:
     # Fallback for testing
     addHook = lambda *args: None  # ty:ignore[invalid-assignment]
     wrap = lambda *args: lambda *a, **k: None  # ty:ignore[invalid-assignment]
-    is_win = is_mac = is_lin = False  # ty:ignore[invalid-assignment]
 
 try:
     import aqt.editor

--- a/src/anki_dictionary/core/hooks.py
+++ b/src/anki_dictionary/core/hooks.py
@@ -27,7 +27,6 @@ try:
     from aqt.qt import QAction, QKeySequence, QMenu, Qt
     from aqt.reviewer import Reviewer
     from aqt.tagedit import TagEdit
-    from aqt.utils import showInfo
 except ImportError:
     # Fallback for testing - use real PyQt if possible
     try:
@@ -37,7 +36,6 @@ except ImportError:
     except ImportError:
         pass
     mw = None  # ty:ignore[invalid-assignment]
-    showInfo = lambda *args: None  # ty:ignore[invalid-assignment]
     AddCards = EditCurrent = Browser = TagEdit = Reviewer = Previewer = object  # ty:ignore[invalid-assignment]
     import sys
 

--- a/src/anki_dictionary/core/hooks.py
+++ b/src/anki_dictionary/core/hooks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Anki integration hooks for the Dictionary Addon.
 
@@ -10,11 +9,10 @@ This module handles all the integration points with Anki, including:
 """
 
 import re
-from typing import Optional
 
 try:
     from anki.hooks import addHook, wrap
-    from anki.utils import is_win, is_mac, is_lin
+    from anki.utils import is_lin, is_mac, is_win
 except ImportError:
     # Fallback for testing
     addHook = lambda *args: None  # ty:ignore[invalid-assignment]
@@ -22,22 +20,22 @@ except ImportError:
     is_win = is_mac = is_lin = False  # ty:ignore[invalid-assignment]
 
 try:
-    from aqt import mw
-    from aqt.qt import QAction, QKeySequence, QMenu, Qt
-    from aqt.utils import showInfo
-    from aqt.addcards import AddCards
-    from aqt.editcurrent import EditCurrent
-    from aqt.browser import Browser
-    from aqt.tagedit import TagEdit
-    from aqt.reviewer import Reviewer
-    from aqt.previewer import Previewer
     import aqt.editor
+    from aqt import mw
+    from aqt.addcards import AddCards
+    from aqt.browser import Browser
+    from aqt.editcurrent import EditCurrent
+    from aqt.previewer import Previewer
+    from aqt.qt import QAction, QKeySequence, QMenu, Qt
+    from aqt.reviewer import Reviewer
+    from aqt.tagedit import TagEdit
+    from aqt.utils import showInfo
 except ImportError:
     # Fallback for testing - use real PyQt if possible
     try:
-        from PyQt6.QtCore import *
-        from PyQt6.QtGui import *
-        from PyQt6.QtWidgets import *
+        from PyQt6.QtCore import *  # noqa: F403
+        from PyQt6.QtGui import *  # noqa: F403
+        from PyQt6.QtWidgets import *  # noqa: F403
     except ImportError:
         pass
     mw = None  # ty:ignore[invalid-assignment]
@@ -47,8 +45,7 @@ except ImportError:
 
     aqt = sys.modules.get("aqt") or object()  # ty:ignore[invalid-assignment]
 
-from ..utils.common import miInfo, getTarget, gt
-from ..utils.paths import get_addon_root
+from ..utils.common import getTarget, gt
 
 # Store the original link handler - will be set on first hook setup
 _original_link_handler = None
@@ -63,7 +60,7 @@ def closeDictionary():
 
 def dictOnStart():
     """Initialize dictionary when profile is loaded."""
-    from ..ui.main_window import removeTempFiles, initGlobalHotkeys
+    from ..ui.main_window import removeTempFiles
 
     removeTempFiles()
     # Uncomment if global hotkeys are enabled
@@ -73,7 +70,7 @@ def dictOnStart():
 
 def addToContextMenu(webview, menu):
     """Add dictionary search to context menu."""
-    from ..ui.main_window import searchTerm, searchCol
+    from ..ui.main_window import searchCol, searchTerm
 
     action1 = menu.addAction("Search in Dictionary")
     action1.triggered.connect(lambda: searchTerm(webview))

--- a/src/anki_dictionary/core/search/coordinator.py
+++ b/src/anki_dictionary/core/search/coordinator.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import time
 import json
-from typing import Any, Callable, Dict, Optional
+from collections.abc import Callable
+from typing import Any
 
 from PyQt6.QtCore import QThreadPool
 
+from ...integrations import forvo as forvo_integration
 from ...integrations import image_search as duckduckgoimages
 from ...integrations import llm as llm_integration
-from ...integrations import forvo as forvo_integration
 from ...utils.logger import get_logger
 
 logger = get_logger(__name__.split(".")[-1])
@@ -26,10 +26,10 @@ class ExternalServiceCoordinator:
         self,
         eval_fn: Any,
         threadpool: QThreadPool,
-        on_llm_result: Optional[Callable[[Dict[str, Any]], None]] = None,
-        on_llm_error: Optional[Callable[[Dict[str, Any]], None]] = None,
-        on_forvo_result: Optional[Callable[[Dict[str, Any]], None]] = None,
-        on_forvo_error: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_llm_result: Callable[[dict[str, Any]], None] | None = None,
+        on_llm_error: Callable[[dict[str, Any]], None] | None = None,
+        on_forvo_result: Callable[[dict[str, Any]], None] | None = None,
+        on_forvo_error: Callable[[dict[str, Any]], None] | None = None,
     ) -> None:
         self._eval = eval_fn
         self._threadpool = threadpool
@@ -43,7 +43,7 @@ class ExternalServiceCoordinator:
     def trigger_llm(
         self,
         term: str,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         star_count: str = "",
         level_labels: str = "",
         id_name: str = "",
@@ -55,13 +55,13 @@ class ExternalServiceCoordinator:
         worker.signals.error_occurred.connect(self._on_llm_error)
         self._threadpool.start(worker)
 
-    def _on_llm_result(self, result: Dict[str, Any]) -> None:
+    def _on_llm_result(self, result: dict[str, Any]) -> None:
         if self._on_llm_result_cb is not None:
             self._on_llm_result_cb(result)
 
-    def _on_llm_error(self, result: Dict[str, Any]) -> None:
+    def _on_llm_error(self, result: dict[str, Any]) -> None:
         error_msg = result.get("error", "Unknown LLM error")
-        logger.warning("LLM error: %s", error_msg)
+        logger.debug("LLM error: %s", error_msg)
         if self._on_llm_error_cb is not None:
             self._on_llm_error_cb(result)
 
@@ -70,9 +70,9 @@ class ExternalServiceCoordinator:
     def trigger_forvo(
         self,
         term: str,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         id_name: str = "",
-        language: Optional[str] = None,
+        language: str | None = None,
     ) -> None:
         if language is None:
             language = config.get("forvo_language", "ja")
@@ -82,7 +82,7 @@ class ExternalServiceCoordinator:
         worker.signals.error_occurred.connect(self._on_forvo_error)
         self._threadpool.start(worker)
 
-    def _on_forvo_result(self, result: Dict[str, Any]) -> None:
+    def _on_forvo_result(self, result: dict[str, Any]) -> None:
         id_name = result.get("idName") or "forvo-loader"
         items = result.get("items", [])
         if not items:
@@ -91,10 +91,9 @@ class ExternalServiceCoordinator:
         if self._on_forvo_result_cb is not None:
             self._on_forvo_result_cb(result)
 
-    def _on_forvo_error(self, result: Dict[str, Any]) -> None:
+    def _on_forvo_error(self, result: dict[str, Any]) -> None:
         error_msg = result.get("error", "Unknown Forvo error")
         logger.warning("Forvo unavailable: %s", error_msg)
-        id_name = result.get("idName") or "forvo-loader"
         if self._on_forvo_error_cb is not None:
             self._on_forvo_error_cb(result)
 
@@ -103,7 +102,7 @@ class ExternalServiceCoordinator:
     def trigger_image_search(
         self,
         term: str,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         id_name: str = "",
         offset: int = 0,
     ) -> None:

--- a/src/anki_dictionary/core/search/pipeline.py
+++ b/src/anki_dictionary/core/search/pipeline.py
@@ -3,21 +3,17 @@ from __future__ import annotations
 import json
 import re
 import time
-import os
-from os.path import join, exists
-from typing import Any, Dict, List, Optional, Tuple
+from os.path import exists, join
+from typing import Any
 
+from ...integrations import llm as llm_integration
 from ...utils.logger import get_logger
-from ...web.icons import get_base64_icon
+from .coordinator import ExternalServiceCoordinator
 from .renderer import (
     ResultRenderer,
     clean_term,
     get_font_family,
-    process_definition_html,
 )
-from .coordinator import ExternalServiceCoordinator
-from ...integrations import llm as llm_integration
-from ...integrations import forvo as forvo_integration
 
 logger = get_logger(__name__.split(".")[-1])
 
@@ -46,7 +42,7 @@ class SearchPipeline:
 
     # ── public entry point ─────────────────────────
 
-    def addNewTab(self, term: str, selected_group: Dict[str, Any]) -> None:
+    def addNewTab(self, term: str, selected_group: dict[str, Any]) -> None:
         if (
             selected_group.get("customFont")
             and selected_group.get("font")
@@ -67,8 +63,8 @@ class SearchPipeline:
     # ── search + render ────────────────────────────
 
     def getHTMLResult(
-        self, term: str, selected_group: Dict[str, Any], id_name: str = ""
-    ) -> Tuple[str, str, str]:
+        self, term: str, selected_group: dict[str, Any], id_name: str = ""
+    ) -> tuple[str, str, str]:
         single_tab = self._get_tab_mode()
         cleaned = clean_term(term)
         font = get_font_family(selected_group)
@@ -124,7 +120,7 @@ class SearchPipeline:
 
     def _prepare_results(
         self,
-        results: Dict[str, Any],
+        results: dict[str, Any],
         term: str,
         font: str,
         id_name: str = "",
@@ -249,7 +245,7 @@ class SearchPipeline:
 
     # ── LLM result injection ───────────────────────
 
-    def loadLLMResults(self, result: Dict[str, Any]) -> None:
+    def loadLLMResults(self, result: dict[str, Any]) -> None:
         dict_name = result.get("dictName", "LLM")
         id_name = result.get("idName") or "llm-loader"
         group = self.midict.dictInt.getSelectedDictGroup()
@@ -302,7 +298,7 @@ class SearchPipeline:
             f"}}"
         )
 
-    def showLLMError(self, result: Dict[str, Any]) -> None:
+    def showLLMError(self, result: dict[str, Any]) -> None:
         error_msg = result.get("error", "Unknown LLM error")
         id_name = result.get("idName") or "llm-loader"
         esc = json.dumps(
@@ -330,7 +326,7 @@ class SearchPipeline:
 
     # ── Forvo result injection ─────────────────────
 
-    def onForvoResult(self, result: Dict[str, Any]) -> None:
+    def onForvoResult(self, result: dict[str, Any]) -> None:
         id_name = result.get("idName") or "forvo-loader"
         term = result.get("term", "")
         items = result.get("items", [])
@@ -406,7 +402,7 @@ class SearchPipeline:
             f"}}"
         )
 
-    def onForvoError(self, result: Dict[str, Any]) -> None:
+    def onForvoError(self, result: dict[str, Any]) -> None:
         error_msg = result.get("error", "Unknown Forvo error")
         logger.warning("Forvo unavailable: %s", error_msg)
         id_name = result.get("idName") or "forvo-loader"
@@ -442,7 +438,7 @@ class SearchPipeline:
 
     # ── image search ───────────────────────────────
 
-    def loadImageResults(self, results: Tuple[str, str]) -> None:
+    def loadImageResults(self, results: tuple[str, str]) -> None:
         html, id_name = results
         self.midict.eval(f"loadImageHtml({json.dumps(html)}, {json.dumps(id_name)});")
 
@@ -455,7 +451,7 @@ class SearchPipeline:
             search_term, self.midict.config, "load_more", offset
         )
 
-    def loadMoreImageResults(self, results: Tuple[str, str]) -> None:
+    def loadMoreImageResults(self, results: tuple[str, str]) -> None:
         html, id_name = results
         if not html or html.strip() == "":
             self.midict.eval(
@@ -476,14 +472,14 @@ class SearchPipeline:
     # ── helpers ────────────────────────────────────
 
     def formatTermHeaders(
-        self, ths: Dict[str, List[str]]
-    ) -> Optional[Dict[str, List[str]]]:
+        self, ths: dict[str, list[str]]
+    ) -> dict[str, list[str]] | None:
         result = self.renderer.format_term_headers(ths)
         return result if result else None
 
-    def loadConjugations(self) -> Dict[str, Any]:
+    def loadConjugations(self) -> dict[str, Any]:
         langs = self.midict.db.getCurrentDbLangs()
-        conv: Dict[str, Any] = {}
+        conv: dict[str, Any] = {}
         for lang in langs:
             fp = join(
                 self.midict.homeDir, "user_files", "db", "conjugation", f"{lang}.json"
@@ -498,14 +494,14 @@ class SearchPipeline:
                 )
                 if not exists(fp):
                     continue
-            with open(fp, "r", encoding="utf-8") as f:
+            with open(fp, encoding="utf-8") as f:
                 conv[lang] = json.loads(f.read())
         return conv
 
     def cleanTerm(self, term: str) -> str:
         return clean_term(term)
 
-    def getFontFamily(self, group: Dict[str, Any]) -> str:
+    def getFontFamily(self, group: dict[str, Any]) -> str:
         return get_font_family(group)
 
     def injectFont(self, font: str) -> None:
@@ -513,7 +509,7 @@ class SearchPipeline:
 
     def formatSingleEntry(
         self,
-        result: Dict[str, Any],
+        result: dict[str, Any],
         dict_name: str,
         font: str,
         front_bracket: str,
@@ -531,7 +527,7 @@ class SearchPipeline:
             is_dark,
         )
 
-    def getCleanedUrls(self, urls: List[str]) -> List[str]:
+    def getCleanedUrls(self, urls: list[str]) -> list[str]:
         from .renderer import get_cleaned_urls
 
         return get_cleaned_urls(urls)
@@ -541,10 +537,10 @@ class SearchPipeline:
     def _get_tab_mode(self) -> str:
         return "true" if self.midict.dictInt.tabB.singleTab else "false"
 
-    def _extract_freq_from_results(self, results: Dict[str, Any]) -> Tuple[str, str]:
+    def _extract_freq_from_results(self, results: dict[str, Any]) -> tuple[str, str]:
         star_count = ""
         level_labels = ""
-        for d_name, d_results in results.items():
+        for _d_name, d_results in results.items():
             if not isinstance(d_results, list):
                 continue
             for entry in d_results:

--- a/src/anki_dictionary/core/search/query.py
+++ b/src/anki_dictionary/core/search/query.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from ...utils.config import get_addon_config
 from ...utils.logger import get_logger
@@ -17,8 +17,8 @@ class SearchQueryBuilder:
     def get_def_ex(self, sT: str) -> bool:
         return sT in ("Definition", "Example")
 
-    def apply_search_type(self, terms: List[str], sT: str) -> List[str]:
-        for idx, term in enumerate(terms):
+    def apply_search_type(self, terms: list[str], sT: str) -> list[str]:
+        for idx, _term in enumerate(terms):
             if sT in ("Forward", "Pronunciation"):
                 terms[idx] = terms[idx] + "%"
             elif sT == "Backward":
@@ -34,9 +34,9 @@ class SearchQueryBuilder:
         return terms
 
     def deconjugate(
-        self, terms: List[str], conjugations: List[Dict[str, Any]]
-    ) -> List[str]:
-        deconjugations: List[str] = []
+        self, terms: list[str], conjugations: list[dict[str, Any]]
+    ) -> list[str]:
+        deconjugations: list[str] = []
         for term in terms:
             for c in conjugations:
                 if term.endswith(c["inflected"]):
@@ -58,7 +58,7 @@ class SearchQueryBuilder:
         return new.join(s.rsplit(old, occurrence))
 
     @staticmethod
-    def get_query_criteria(col: str, terms: List[str], op: str = "LIKE") -> str:
+    def get_query_criteria(col: str, terms: list[str], op: str = "LIKE") -> str:
         clauses = [f" {col} {op} ? " for _ in terms]
         return " OR ".join(clauses)
 
@@ -85,7 +85,7 @@ class SearchQueryBuilder:
         return re.sub(r"<((?:[^b][^r])|(?:[b][^r]))", r"&lt;\1", str(text))
 
     @staticmethod
-    def result_to_dict(r: Tuple[Any, ...]) -> Dict[str, Any]:
+    def result_to_dict(r: tuple[Any, ...]) -> dict[str, Any]:
         frequency: Any = r[8] if len(r) > 8 else ""
         return {
             "term": r[0],
@@ -105,8 +105,8 @@ class SearchQueryBuilder:
         dict_name: str,
         to_query: str,
         dict_limit: int,
-        term_tuple: Tuple[Any, ...],
-    ) -> List[Tuple[Any, ...]]:
+        term_tuple: tuple[Any, ...],
+    ) -> list[tuple[Any, ...]]:
         cursor = self._db._get_cursor()
         safe_table = self._quote_identifier(dict_name)
         cols = "term, altterm, pronunciation, pos, definition, examples, audio, starCount, frequency"
@@ -125,8 +125,8 @@ class SearchQueryBuilder:
             return []
 
     def get_term_frequency_info(
-        self, term: str, lang: str, config: Dict[str, Any]
-    ) -> Dict[str, Any]:
+        self, term: str, lang: str, config: dict[str, Any]
+    ) -> dict[str, Any]:
         if not lang:
             return {"term": term, "starCount": "", "levelLabels": ""}
         providers = self._db._get_extra_data(lang)
@@ -144,24 +144,24 @@ class SearchQueryBuilder:
 
     def _apply_frequency_info(
         self,
-        entry: Dict[str, Any],
-        providers: List[Any],
-        config: Dict[str, Any],
+        entry: dict[str, Any],
+        providers: list[Any],
+        config: dict[str, Any],
     ) -> None:
         self._db._apply_frequency_info(entry, providers, config)
 
     def search(
         self,
         term: str,
-        selected_group: Dict[str, Any],
-        conjugations: Dict[str, List[Dict[str, Any]]],
+        selected_group: dict[str, Any],
+        conjugations: dict[str, list[dict[str, Any]]],
         sT: str,
         deinflect: bool,
         dict_limit: int,
         max_defs: int,
-    ) -> Dict[str, Any]:
-        already_conj_typed: Dict[str, List[str]] = {}
-        results: Dict[str, Any] = {}
+    ) -> dict[str, Any]:
+        already_conj_typed: dict[str, list[str]] = {}
+        results: dict[str, Any] = {}
         group = selected_group["dictionaries"]
         total_defs = 0
         def_ex = self.get_def_ex(sT)
@@ -270,10 +270,10 @@ class SearchQueryBuilder:
 
     def get_def_for_mass_exp(
         self, term: str, dN: str, limit: int, rN: str
-    ) -> Tuple[List[Dict[str, Any]], Any, Any]:
+    ) -> tuple[list[dict[str, Any]], Any, Any]:
         dup_result = self._db.getDuplicateSetting(rN)
         duplicate_header, term_header = dup_result if dup_result else (None, None)
-        results: List[Dict[str, Any]] = []
+        results: list[dict[str, Any]] = []
         for col in ("term", "altterm", "pronunciation"):
             terms = [term]
             to_query = f" {col} = ? "

--- a/src/anki_dictionary/core/search/renderer.py
+++ b/src/anki_dictionary/core/search/renderer.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import json
 import re
-import os
-from os.path import join, exists
-from typing import Any, Dict, List, Tuple
+from os.path import exists, join
+from typing import Any
 
 from ...utils.logger import get_logger
 
@@ -20,7 +19,7 @@ def clean_term(term: str) -> str:
     )
 
 
-def get_font_family(group: Dict[str, Any]) -> str:
+def get_font_family(group: dict[str, Any]) -> str:
     if not group.get("font"):
         return " "
     if group.get("customFont"):
@@ -46,7 +45,7 @@ def process_definition_html(text: Any) -> str:
     return text.strip()
 
 
-def get_cleaned_urls(urls: List[str]) -> List[str]:
+def get_cleaned_urls(urls: list[str]) -> list[str]:
     return [
         u
         for u in urls
@@ -69,7 +68,7 @@ class ResultRenderer:
 
     # ── helpers ────────────────────────────────────
 
-    def get_tooltips(self, config: Dict[str, Any]) -> Tuple[str, str, str]:
+    def get_tooltips(self, config: dict[str, Any]) -> tuple[str, str, str]:
         if not config.get("tooltips", True):
             return "", "", ""
 
@@ -122,7 +121,7 @@ class ResultRenderer:
         except Exception:
             return ""
 
-    def highlight_target(self, text: str, term: str, config: Dict[str, Any]) -> str:
+    def highlight_target(self, text: str, term: str, config: dict[str, Any]) -> str:
         if not config.get("highlightTarget", False):
             return text
         if not isinstance(text, str):
@@ -148,10 +147,10 @@ class ResultRenderer:
             logger.error("Error during highlight_target: %s", e)
             return text
 
-    def format_term_headers(self, ths: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    def format_term_headers(self, ths: dict[str, list[str]]) -> dict[str, list[str]]:
         if not ths:
             return {}
-        formatted: Dict[str, List[str]] = {}
+        formatted: dict[str, list[str]] = {}
         for dictname, headers in ths.items():
             header_str = ""
             sb_str = ""
@@ -183,8 +182,8 @@ class ResultRenderer:
         term: str,
         altterm: str,
         pronunciation: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
         sb: bool = False,
     ) -> str:
         alt_fb = front_bracket
@@ -247,13 +246,13 @@ class ResultRenderer:
 
     def get_sidebar(
         self,
-        results: Dict[str, Any],
+        results: dict[str, Any],
         term: str,
         font: str,
         front_bracket: str,
         back_bracket: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
     ) -> str:
         html = "<div" + font + 'class="definitionSideBar"><div class="innerSideBar">'
         dict_count = 0
@@ -323,7 +322,7 @@ class ResultRenderer:
 
     # ── definition cleaning ────────────────────────
 
-    def clean_definition(self, entry: Dict[str, Any]) -> Tuple[str, str]:
+    def clean_definition(self, entry: dict[str, Any]) -> tuple[str, str]:
         definition = entry["definition"].strip()
         extracted_freq = ""
 
@@ -365,15 +364,15 @@ class ResultRenderer:
 
     def render_term_pronunciation_block(
         self,
-        entry: Dict[str, Any],
+        entry: dict[str, Any],
         dict_name: str,
         clean_name: str,
         font: str,
         front_bracket: str,
         back_bracket: str,
         extracted_freq: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
         img_tooltip: str = "",
         clip_tooltip: str = "",
         send_tooltip: str = "",
@@ -434,7 +433,7 @@ class ResultRenderer:
         )
 
     def render_definition_block(
-        self, definition: str, font: str, term: str, config: Dict[str, Any]
+        self, definition: str, font: str, term: str, config: dict[str, Any]
     ) -> str:
         return (
             "<div"
@@ -493,13 +492,13 @@ class ResultRenderer:
 
     def render_llm_entry(
         self,
-        result: Dict[str, Any],
+        result: dict[str, Any],
         dict_name: str,
         font: str,
         front_bracket: str,
         back_bracket: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
         is_dark: bool = False,
     ) -> str:
         img, clip, send = self.get_tooltips(config)
@@ -550,20 +549,20 @@ class ResultRenderer:
         )
 
     def render_llm_definition_block(
-        self, definition: str, font: str, term: str, config: Dict[str, Any]
+        self, definition: str, font: str, term: str, config: dict[str, Any]
     ) -> str:
         processed = self.process_llm_definition(definition, term)
         return self.render_definition_block(processed, font, term, config)
 
     def format_single_entry(
         self,
-        result: Dict[str, Any],
+        result: dict[str, Any],
         dict_name: str,
         font: str,
         front_bracket: str,
         back_bracket: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
         is_dark: bool = False,
     ) -> str:
         img, clip, send = self.get_tooltips(config)
@@ -639,8 +638,8 @@ class ResultRenderer:
         font: str,
         front_bracket: str,
         back_bracket: str,
-        config: Dict[str, Any],
-        term_headers: Dict[str, List[str]] | None = None,
+        config: dict[str, Any],
+        term_headers: dict[str, list[str]] | None = None,
         id_name: str = "",
         is_dark: bool = False,
         settings_html: str = "",

--- a/src/anki_dictionary/core/word_list_registry.py
+++ b/src/anki_dictionary/core/word_list_registry.py
@@ -5,18 +5,17 @@ import os
 import re
 import shutil
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from ..utils.logger import get_logger
-from ..utils.paths import get_db_dir
 
 logger = get_logger("word_list_registry")
 
 
 @dataclass
 class LookupResult:
-    rank: Optional[int] = None
-    levels: List[str] = field(default_factory=list)
+    rank: int | None = None
+    levels: list[str] = field(default_factory=list)
     reading: str = ""
 
 
@@ -34,7 +33,7 @@ class WordListProvider:
         self.lang = lang
         self.description = description
         self._data = data
-        self._index: Optional[Dict[str, Any]] = None
+        self._index: dict[str, Any] | None = None
 
         if isinstance(data, dict):
             if "index" in data and isinstance(data["index"], dict):
@@ -141,7 +140,7 @@ class WordListProvider:
 
         return result
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "type": self.type,
             "name": self.name,
@@ -155,7 +154,7 @@ class WordListRegistry:
 
     def __init__(self, db_dir: str) -> None:
         self._dir = os.path.join(db_dir, self.DATA_DIR)
-        self._cache: Dict[str, List[WordListProvider]] = {}
+        self._cache: dict[str, list[WordListProvider]] = {}
         self._migrated = False
 
     @property
@@ -164,14 +163,14 @@ class WordListRegistry:
 
     _TYPE_TAGS = {".freq": "rank", ".level": "level"}
 
-    def get_providers(self, lang: str) -> List[WordListProvider]:
+    def get_providers(self, lang: str) -> list[WordListProvider]:
         if lang in self._cache:
             return self._cache[lang]
 
         self._ensure_migration()
         os.makedirs(self._dir, exist_ok=True)
 
-        providers: List[WordListProvider] = []
+        providers: list[WordListProvider] = []
         prefix_underscore = lang.replace(" ", "_") + "_"
         prefix_space = lang + " "
 
@@ -189,7 +188,7 @@ class WordListRegistry:
 
                 filepath = os.path.join(self._dir, filename)
                 try:
-                    with open(filepath, "r", encoding="utf-8-sig") as f:
+                    with open(filepath, encoding="utf-8-sig") as f:
                         data = json.load(f)
                 except Exception as e:
                     logger.error(f"Error loading {filepath}: {e}")
@@ -239,7 +238,7 @@ class WordListRegistry:
             "frequency": "rank",
             "hsk": "level",
         }
-        for old_name, type_ in old_dirs.items():
+        for old_name, _ in old_dirs.items():
             old_path = os.path.join(db_dir, old_name)
             if not os.path.isdir(old_path):
                 continue
@@ -248,7 +247,7 @@ class WordListRegistry:
                     continue
                 src = os.path.join(old_path, fname)
                 try:
-                    with open(src, "r", encoding="utf-8-sig") as f:
+                    with open(src, encoding="utf-8-sig") as f:
                         json.load(f)
                 except Exception as e:
                     logger.error(f"Error reading legacy {old_name}/{fname}: {e}")
@@ -277,7 +276,7 @@ class WordListRegistry:
             except OSError as e:
                 logger.debug(f"Could not remove legacy directory {old_path}: {e}")
 
-    def clear_cache(self, lang: Optional[str] = None) -> None:
+    def clear_cache(self, lang: str | None = None) -> None:
         if lang:
             self._cache.pop(lang, None)
         else:

--- a/src/anki_dictionary/exporters/bulk_processor.py
+++ b/src/anki_dictionary/exporters/bulk_processor.py
@@ -1,16 +1,14 @@
 from dataclasses import dataclass
 from os.path import join
-from typing import Optional
 
 from aqt.qt import (
     QApplication,
     QIcon,
     QLabel,
     QProgressBar,
-    QScreen,
+    Qt,
     QVBoxLayout,
     QWidget,
-    Qt,
 )
 
 from ..utils.common import miInfo
@@ -32,7 +30,7 @@ class BulkProcessor:
         self._dict_int = dict_int
         self._always_on_top = always_on_top
         self.text_importing = False
-        self.media_export_progress_window: Optional[_MediaProgress] = None
+        self.media_export_progress_window: _MediaProgress | None = None
 
     def bulk_text_export(self, cards, add_text_card_fn):
         self.text_importing = True
@@ -47,7 +45,7 @@ class BulkProcessor:
             if not self.text_importing:
                 miInfo(
                     "Importing cards from the extension has been cancelled."
-                    "\n\n{} of {} were added.".format(idx, total),
+                    f"\n\n{idx} of {total} were added.",
                 )
                 return
             add_text_card_fn(card)
@@ -95,9 +93,9 @@ class BulkProcessor:
             if state.current_value == state.total:
                 total = state.total
                 if total == 1:
-                    miInfo("{} card has been imported.".format(total))
+                    miInfo(f"{total} card has been imported.")
                 else:
-                    miInfo("{} cards have been imported.".format(total))
+                    miInfo(f"{total} cards have been imported.")
                 self._close_progress_bar(state.widget)
                 self.media_export_progress_window = None
         except Exception:
@@ -108,9 +106,7 @@ class BulkProcessor:
         if state:
             miInfo(
                 "Importing cards from the extension has been cancelled from"
-                " within the browser.\n\n {} cards were imported.".format(
-                    state.current_value
-                )
+                f" within the browser.\n\n {state.current_value} cards were imported."
             )
             self._close_progress_bar(state.widget)
             self.media_export_progress_window = None
@@ -132,9 +128,7 @@ class BulkProcessor:
                 if not closed_because_finished_importing:
                     self._mw.DictBulkMediaExportWasCancelled = True
                     miInfo(
-                        "Importing cancelled.\n\n{} cards were imported.".format(
-                            current_value
-                        )
+                        f"Importing cancelled.\n\n{current_value} cards were imported."
                     )
 
         text_display = QLabel()

--- a/src/anki_dictionary/exporters/card_exporter.py
+++ b/src/anki_dictionary/exporters/card_exporter.py
@@ -1,6 +1,11 @@
-# -*- coding: utf-8 -*-
 #
 
+import re
+from os.path import join
+
+from anki import sound
+from anki.notes import Note
+from anki.utils import is_mac
 from aqt import dialogs
 from aqt.qt import (
     QAbstractItemView,
@@ -18,37 +23,31 @@ from aqt.qt import (
     QScrollArea,
     QShortcut,
     QSpinBox,
+    Qt,
     QTableWidget,
     QTableWidgetItem,
     QTextCharFormat,
     QTextEdit,
     QVBoxLayout,
     QWidget,
-    Qt,
 )
-from anki.utils import is_mac
 from aqt.utils import ensureWidgetInScreenBoundaries
-from os.path import join
-from ..utils.common import miInfo, miAsk
+
+from ..utils.common import miAsk, miInfo
 from ..utils.config import get_addon_config
-from anki.notes import Note
-from anki import sound
-import re
-
-from . import note_creator
 from ..utils.logger import get_logger
-
+from . import note_creator
+from .bulk_processor import BulkProcessor
 from .html_cleaner import HtmlCleaner
 from .media_transfer import MediaTransfer
 from .note_assembler import NoteAssembler
-from .bulk_processor import BulkProcessor
 
 logger = get_logger(__name__.split(".")[-1])
 
 
 class MITextEdit(QTextEdit):
     def __init__(self, parent=None, dictInt=None):
-        super(MITextEdit, self).__init__(parent)
+        super().__init__(parent)
         self.dictInt = dictInt
         self.setAcceptRichText(False)
 
@@ -94,9 +93,7 @@ class MITextEdit(QTextEdit):
     def searchSelected(self, in_browser):
         if in_browser:
             b = dialogs.open("Browser", self.dictInt.mw)  # ty:ignore[unresolved-attribute]
-            b.form.searchEdit.lineEdit().setText(
-                "expression:*{0}*".format(self.selectedText())
-            )
+            b.form.searchEdit.lineEdit().setText(f"expression:*{self.selectedText()}*")
             b.onSearchActivated()
         else:
             self.dictInt.initSearch(self.selectedText())  # ty:ignore[unresolved-attribute]
@@ -107,7 +104,7 @@ class MITextEdit(QTextEdit):
 
 class MILineEdit(QLineEdit):
     def __init__(self, parent=None, dictInt=None):
-        super(MILineEdit, self).__init__(parent)
+        super().__init__(parent)
         self.dictInt = dictInt
 
     def contextMenuEvent(self, event):  # ty:ignore[invalid-method-override]
@@ -120,9 +117,7 @@ class MILineEdit(QLineEdit):
     def searchSelected(self, in_browser):
         if in_browser:
             b = dialogs.open("Browser", self.dictInt.mw)  # ty:ignore[unresolved-attribute]
-            b.form.searchEdit.lineEdit().setText(
-                "Expression:*{0}*".format(self.selectedText())
-            )
+            b.form.searchEdit.lineEdit().setText(f"Expression:*{self.selectedText()}*")
             b.onSearchActivated()
         else:
             self.dictInt.initSearch(self.selectedText())  # ty:ignore[unresolved-attribute]
@@ -133,11 +128,13 @@ class CardExporter:
         self,
         dictInt,
         dictWeb,
-        templates=[],
+        templates=None,
         sentence=False,
         word=False,
         definition=False,
     ):
+        if templates is None:
+            templates = []
         self.window = QWidget()
         self.scrollArea = QScrollArea()
         self.scrollArea.setWidget(self.window)

--- a/src/anki_dictionary/exporters/card_exporter.py
+++ b/src/anki_dictionary/exporters/card_exporter.py
@@ -133,8 +133,6 @@ class CardExporter:
         word=False,
         definition=False,
     ):
-        if _unused_templates is None:
-            templates = []
         self.window = QWidget()
         self.scrollArea = QScrollArea()
         self.scrollArea.setWidget(self.window)

--- a/src/anki_dictionary/exporters/card_exporter.py
+++ b/src/anki_dictionary/exporters/card_exporter.py
@@ -128,12 +128,12 @@ class CardExporter:
         self,
         dictInt,
         dictWeb,
-        templates=None,
+        _unused_templates=None,
         sentence=False,
         word=False,
         definition=False,
     ):
-        if templates is None:
+        if _unused_templates is None:
             templates = []
         self.window = QWidget()
         self.scrollArea = QScrollArea()

--- a/src/anki_dictionary/exporters/html_cleaner.py
+++ b/src/anki_dictionary/exporters/html_cleaner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import re
@@ -32,7 +31,7 @@ class HtmlCleaner:
         )
 
         # Switch paragraphs to <br>
-        text = re.sub(r"</p>", r"<br />", text, re.S)
+        text = re.sub(r"</p>", r"<br />", text, flags=re.S)
 
         # Trim unneeded bits
         text = re.sub(r".+</head>", r"", text, flags=re.S)

--- a/src/anki_dictionary/exporters/note_assembler.py
+++ b/src/anki_dictionary/exporters/note_assembler.py
@@ -122,7 +122,7 @@ class NoteAssembler:
                         definition_list, dictionary
                     )
         unspecified = template["unspecified"]
-        for idx, def_list in enumerate(definition_list):
+        for _idx, def_list in enumerate(definition_list):
             if unspecified not in fields:
                 fields[unspecified] = [def_list[2]]
             else:

--- a/src/anki_dictionary/exporters/note_creator.py
+++ b/src/anki_dictionary/exporters/note_creator.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
-from anki.notes import Note
 from anki.collection import Collection
+from anki.notes import Note
 
 
 def add_note(note: Note, did: int, collection: Collection) -> None:
     collection.add_note(note, did)  # ty:ignore[invalid-argument-type]
 
 
-def get_decks(collection: Collection) -> List[Tuple[int, str]]:
+def get_decks(collection: Collection) -> list[tuple[int, str]]:
     decks = collection.decks.all_names_and_ids()
     return [(d.id, d.name) for d in decks]
 
 
 def get_fields_values(
-    config: Dict[str, Any], db: Any, note: Note, template: str
-) -> Dict[str, str]:
+    config: dict[str, Any], db: Any, note: Note, template: str
+) -> dict[str, str]:
     field_map = config.get("fieldNameToValue", {})
     fields_config = config.get("fieldConfig", {})
-    values: Dict[str, str] = {}
+    values: dict[str, str] = {}
     nt = note.note_type()
     if nt is None:
         return values
@@ -49,7 +49,7 @@ def automatically_add_definitions(
                 note[name] = word
 
 
-def extract_freq_info(entry: Dict[str, Any], config: Dict[str, Any]) -> Tuple[str, str]:
+def extract_freq_info(entry: dict[str, Any], config: dict[str, Any]) -> tuple[str, str]:
     star_count = entry.get("starCount", "")
     level_labels = entry.get("levelLabels", "")
     return star_count, level_labels

--- a/src/anki_dictionary/integrations/forvo.py
+++ b/src/anki_dictionary/integrations/forvo.py
@@ -1,22 +1,22 @@
-# -*- coding: utf-8 -*-
 """
 Forvo Integration for Anki Dictionary.
 Scrapes pronunciations from Forvo.com.
 """
 
-import re
 import base64
+import re
 import subprocess
 import sys
 import time
-from typing import Dict, Any, Tuple
-from bs4 import BeautifulSoup
 import urllib.parse
+from typing import Any
+
+from bs4 import BeautifulSoup
 
 try:
-    from aqt.qt import QObject, pyqtSignal, QRunnable
+    from aqt.qt import QObject, QRunnable, pyqtSignal
 except ImportError:
-    from PyQt6.QtCore import QObject, pyqtSignal, QRunnable
+    from PyQt6.QtCore import QObject, QRunnable, pyqtSignal
 
 from ..utils.logger import get_logger
 
@@ -69,7 +69,7 @@ class ForvoWorkerSignals(QObject):
     finished = pyqtSignal()
 
 
-def _fetch_url(url: str, timeout: int = 15) -> Tuple[int, str]:
+def _fetch_url(url: str, timeout: int = 15) -> tuple[int, str]:
     """Fetch a Forvo page using curl, which bypasses Cloudflare TLS fingerprinting."""
     last_error = None
     for attempt in range(3):
@@ -123,7 +123,7 @@ class ForvoWorker(QRunnable):
     """Worker for scraping Forvo in a separate thread."""
 
     def __init__(
-        self, term: str, language_code: str, config: Dict[str, Any], idName: str = ""
+        self, term: str, language_code: str, config: dict[str, Any], idName: str = ""
     ):
         super().__init__()
         self.term = term

--- a/src/anki_dictionary/integrations/image_search.py
+++ b/src/anki_dictionary/integrations/image_search.py
@@ -104,8 +104,8 @@ def _make_session():
     """
     if _ON_MAC:
         try:
-            from curl_cffi import (
-                requests as curl_requests,  # ty:ignore[unresolved-import]
+            from curl_cffi import (  # ty:ignore[unresolved-import]
+                requests as curl_requests,
             )
         except ImportError:
             # Inject vendor paths manually using our known addon_path
@@ -122,8 +122,8 @@ def _make_session():
                 sys.path.insert(0, mac_vendor)
 
             try:
-                from curl_cffi import (
-                    requests as curl_requests,  # ty:ignore[unresolved-import]
+                from curl_cffi import (  # ty:ignore[unresolved-import]
+                    requests as curl_requests,
                 )
             except ImportError as e:
                 # Log the exact error to diagnose C-extension mismatches (e.g., Python 3.9 vs 3.12)

--- a/src/anki_dictionary/integrations/image_search.py
+++ b/src/anki_dictionary/integrations/image_search.py
@@ -1,27 +1,26 @@
-# -*- coding: utf-8 -*-
-
+import concurrent.futures
+import hashlib
+import json
 import os
 import platform
-from os.path import dirname, join
-import requests
 import re
 import ssl
-import hashlib
-import concurrent.futures
-import json
+import urllib.parse
+from os.path import dirname, join
+
+import requests
 import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
-import urllib.parse
 
 try:
-    from aqt.qt import QRunnable, QObject, pyqtSignal, QImage, QSize, Qt
+    from aqt.qt import QImage, QObject, QRunnable, QSize, Qt, pyqtSignal
 except ImportError:
-    from PyQt6.QtCore import QRunnable, QObject, pyqtSignal, QSize, Qt
+    from PyQt6.QtCore import QObject, QRunnable, QSize, Qt, pyqtSignal
     from PyQt6.QtGui import QImage
 
-from ..utils.constants import COUNTRY_TO_DDG
 from ..utils.common import prefer_ipv4
+from ..utils.constants import COUNTRY_TO_DDG
 from ..utils.logger import get_logger
 
 logger = get_logger("ImageSearch")
@@ -105,7 +104,9 @@ def _make_session():
     """
     if _ON_MAC:
         try:
-            from curl_cffi import requests as curl_requests  # ty:ignore[unresolved-import]
+            from curl_cffi import (
+                requests as curl_requests,  # ty:ignore[unresolved-import]
+            )
         except ImportError:
             # Inject vendor paths manually using our known addon_path
             import sys
@@ -121,7 +122,9 @@ def _make_session():
                 sys.path.insert(0, mac_vendor)
 
             try:
-                from curl_cffi import requests as curl_requests  # ty:ignore[unresolved-import]
+                from curl_cffi import (
+                    requests as curl_requests,  # ty:ignore[unresolved-import]
+                )
             except ImportError as e:
                 # Log the exact error to diagnose C-extension mismatches (e.g., Python 3.9 vs 3.12)
                 log_debug(f"[ImageSearch] curl_cffi import failed: {e}")
@@ -225,11 +228,7 @@ class DuckDuckGo(QRunnable):
 
             if response.status_code == 200:
                 # Some curl_cffi versions return JSON directly, fallback to .json()
-                data = (
-                    response.json()
-                    if hasattr(response.json, "__call__")
-                    else response.json
-                )
+                data = response.json() if callable(response.json) else response.json
                 return [img["image"] for img in data.get("results", [])][:maximum]
         except Exception as e:
             log_debug(f"[ImageSearch] Error in search: {e}")

--- a/src/anki_dictionary/integrations/llm.py
+++ b/src/anki_dictionary/integrations/llm.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
 """
 LLM Integration for Anki Dictionary.
 Supports OpenAI-compatible APIs and Ollama /api/chat.
 """
 
-import requests
-import json
 import re
-from typing import Optional, Dict, Any, Callable, Tuple
+from collections.abc import Callable
+from typing import Any
+
+import requests
 
 from ..utils.logger import get_logger
 
@@ -21,10 +21,10 @@ LLM_DELIMITER_INSTRUCTION = (
 )
 
 try:
-    from aqt.qt import QObject, pyqtSignal, QRunnable
+    from aqt.qt import QObject, QRunnable, pyqtSignal
 except ImportError:
     # Fallback to standard PyQt6 for standalone testing/development
-    from PyQt6.QtCore import QObject, pyqtSignal, QRunnable
+    from PyQt6.QtCore import QObject, QRunnable, pyqtSignal
 
 
 class LLMWorkerSignals(QObject):
@@ -39,9 +39,9 @@ def prepare_llm_payload(
     base_url: str,
     model: str,
     content: str,
-    config: Dict[str, Any],
+    config: dict[str, Any],
     is_test: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Prepare the request payload based on the endpoint type.
     Handles Ollama /api/chat and standard OpenAI formats.
@@ -78,7 +78,7 @@ def prepare_llm_payload(
         return payload
 
 
-def extract_llm_content(data: Dict[str, Any], base_url: str) -> str:
+def extract_llm_content(data: dict[str, Any], base_url: str) -> str:
     """
     Extract the response content from various API formats.
     """
@@ -121,7 +121,7 @@ def split_llm_definitions(content: str) -> list[str]:
     return [c for c in chunks if c]
 
 
-def clean_llm_content(content: str, config: Dict[str, Any]) -> str:
+def clean_llm_content(content: str, config: dict[str, Any]) -> str:
     """
     Remove thinking tags and perform basic cleanup based on configuration.
     """
@@ -141,7 +141,7 @@ class LLMWorker(QRunnable):
     def __init__(
         self,
         term: str,
-        config: Dict[str, Any],
+        config: dict[str, Any],
         star_count: str = "",
         level_labels: str = "",
         idName: str = "",
@@ -246,7 +246,7 @@ class LLMWorker(QRunnable):
             self.signals.finished.emit()
 
 
-def test_llm_config(config: Dict[str, Any], callback: Callable[[bool, str], None]):
+def test_llm_config(config: dict[str, Any], callback: Callable[[bool, str], None]):
     """
     Test the LLM configuration with a simple ping.
     This runs synchronously and should be called from a thread.

--- a/src/anki_dictionary/ui/dialogs/dict_import.py
+++ b/src/anki_dictionary/ui/dialogs/dict_import.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import aqt
 import json
-import zipfile
 import re
-import os
-from typing import Any, Dict, List, Optional, Tuple
+import zipfile
+from typing import Any
+
+import aqt
 from aqt.qt import QMessageBox, QWidget
 
-from ...utils.paths import get_db_dir
 from ...utils.logger import get_logger
 
 log = get_logger("dict_import")
@@ -24,8 +23,8 @@ def importDict(
 
     try:
         zfile = zipfile.ZipFile(file)
-    except zipfile.BadZipFile:
-        raise ValueError("Dictionary archive is invalid.")
+    except zipfile.BadZipFile as e:
+        raise ValueError("Dictionary archive is invalid.") from e
 
     has_term_bank = any(fn.startswith("term_bank_") for fn in zfile.namelist())
     has_index = any(fn == "index.json" for fn in zfile.namelist())
@@ -94,7 +93,7 @@ def importDict(
     return final_name
 
 
-def natural_sort(l: List[str]) -> List[str]:
+def natural_sort(l: list[str]) -> list[str]:
     convert = lambda text: int(text) if text.isdigit() else text.lower()
     alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
     return sorted(l, key=alphanum_key)
@@ -102,7 +101,7 @@ def natural_sort(l: List[str]) -> List[str]:
 
 def loadDict(
     zfile: zipfile.ZipFile,
-    filenames: List[str],
+    filenames: list[str],
     lang: str,
     dictName: str,
     miDict: bool = False,
@@ -161,7 +160,7 @@ def getAdjustedDefinition(definition: str) -> str:
     return definition
 
 
-def handlePitchDictEntry(jsonDict: List, count: int, entry: Any) -> None:
+def handlePitchDictEntry(jsonDict: list, count: int, entry: Any) -> None:
     term = ""
     altterm = ""
     reading = ""
@@ -171,13 +170,9 @@ def handlePitchDictEntry(jsonDict: List, count: int, entry: Any) -> None:
     audio = ""
     frequency = ""
     starCount = ""
-    pitch_accent = ""
 
     term = entry[0]
     reading = entry[2].get("reading", entry[0])
-    pitch_accent = (
-        entry[2]["pitches"][0].get("position") if entry[2]["pitches"] else None
-    )
 
     jsonDict[count] = (
         term,
@@ -192,7 +187,7 @@ def handlePitchDictEntry(jsonDict: List, count: int, entry: Any) -> None:
     )
 
 
-def handleMiDictEntry(jsonDict: List, count: int, entry: Any) -> None:
+def handleMiDictEntry(jsonDict: list, count: int, entry: Any) -> None:
     if isinstance(entry, list):
         term = entry[0] if len(entry) > 0 else ""
         altterm = entry[1] if len(entry) > 1 else ""
@@ -235,7 +230,7 @@ def handleMiDictEntry(jsonDict: List, count: int, entry: Any) -> None:
     )
 
 
-def handleYomiDictEntry(jsonDict: List, count: int, entry: Any) -> None:
+def handleYomiDictEntry(jsonDict: list, count: int, entry: Any) -> None:
     def extract_definition(items: Any) -> str:
         def recursive_extract(item):
             if isinstance(item, str):
@@ -265,7 +260,7 @@ def handleYomiDictEntry(jsonDict: List, count: int, entry: Any) -> None:
                 definitions.append(text)
         return "<br/>".join(definitions)
 
-    def find_header_section(items: Any) -> List:
+    def find_header_section(items: Any) -> list:
         if isinstance(items, list):
             for item in items:
                 if isinstance(item, dict):
@@ -275,8 +270,8 @@ def handleYomiDictEntry(jsonDict: List, count: int, entry: Any) -> None:
                         return item.get("content", [])
         return []
 
-    def extract_pitch(content: Any) -> List[int]:
-        accents: List[int] = []
+    def extract_pitch(content: Any) -> list[int]:
+        accents: list[int] = []
 
         def recursive_search(item: Any) -> None:
             if isinstance(item, dict) and "data" in item:

--- a/src/anki_dictionary/ui/dialogs/dict_import.py
+++ b/src/anki_dictionary/ui/dialogs/dict_import.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 import zipfile
-from typing import Any
+from typing import Any, BinaryIO
 
 import aqt
 from aqt.qt import QMessageBox, QWidget
@@ -14,7 +14,7 @@ log = get_logger("dict_import")
 
 
 def importDict(
-    lang_name: str, file: str, dict_name: str, parent: QWidget | None = None
+    lang_name: str, file: str | BinaryIO, dict_name: str, parent: QWidget | None = None
 ) -> None:
     db = aqt.mw.miDictDB  # ty:ignore[unresolved-attribute]
 

--- a/src/anki_dictionary/ui/dialogs/dict_importer_widget.py
+++ b/src/anki_dictionary/ui/dialogs/dict_importer_widget.py
@@ -9,8 +9,8 @@ from aqt.qt import (
     QFileDialog,
     QMessageBox,
     QProgressDialog,
-    QTreeWidgetItem,
     Qt,
+    QTreeWidgetItem,
 )
 
 from ...utils.logger import get_logger
@@ -170,7 +170,7 @@ class DictImporter:
             except Exception:
                 pass
 
-        self.parent.info('Imported data as "%s" for "%s".' % (filename, lang_name))
+        self.parent.info(f'Imported data as "{filename}" for "{lang_name}".')
 
     def web_freq_data(self):
         lang_item = self.parent.tree_manager.get_current_lang_item()
@@ -197,7 +197,7 @@ class DictImporter:
         conj_path = os.path.join(get_db_dir(), "conjugation")
         os.makedirs(conj_path, exist_ok=True)
 
-        dst_path = os.path.join(conj_path, "%s.json" % lang_name)
+        dst_path = os.path.join(conj_path, f"{lang_name}.json")
 
         try:
             shutil.copy(path, dst_path)
@@ -205,7 +205,7 @@ class DictImporter:
             self.parent.info("Importing conjugation data failed.")
             return
 
-        self.parent.info('Imported conjugation data for "%s".' % lang_name)
+        self.parent.info(f'Imported conjugation data for "{lang_name}".')
 
     def web_conj_data(self):
         lang_item = self.parent.tree_manager.get_current_lang_item()
@@ -261,7 +261,7 @@ class DictImporter:
         term_txt = ", ".join(json.loads(db.getDictTermHeader(dict_clean)))
 
         term_txt, ok = self.parent.get_string(
-            'Set term header for dictionary "%s"' % dict_clean.replace("_", " "),
+            'Set term header for dictionary "{}"'.format(dict_clean.replace("_", " ")),
             term_txt,
         )
 
@@ -275,7 +275,7 @@ class DictImporter:
         for part_txt in parts_txt:
             part = part_txt.strip().lower()
             if part not in valid_parts:
-                self.parent.info('The term header part "%s" is not valid.' % part_txt)
+                self.parent.info(f'The term header part "{part_txt}" is not valid.')
                 return
             parts.append(part)
 

--- a/src/anki_dictionary/ui/dialogs/dictionary_manager.py
+++ b/src/anki_dictionary/ui/dialogs/dictionary_manager.py
@@ -15,7 +15,6 @@ from aqt.qt import (
 
 from ...utils.logger import get_logger
 from .dict_importer_widget import DictImporter
-from .dict_import import importDict
 from .language_manager_widget import LanguageManager
 from .tree_manager_widget import TreeManager
 
@@ -24,7 +23,7 @@ logger = get_logger(__name__.split(".")[-1])
 
 class DictionaryManagerWidget(QWidget):
     def __init__(self, mw, parent=None):
-        super(DictionaryManagerWidget, self).__init__(parent)
+        super().__init__(parent)
         self.mw = mw
         self.tree_manager = TreeManager(mw, self)
         self.dict_importer = DictImporter(mw, self)

--- a/src/anki_dictionary/ui/dialogs/language_manager_widget.py
+++ b/src/anki_dictionary/ui/dialogs/language_manager_widget.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 import aqt
-from aqt.qt import QMessageBox, QTreeWidgetItem, Qt
+from aqt.qt import QMessageBox, Qt, QTreeWidgetItem
 
 from ...utils.logger import get_logger
 from ...utils.paths import get_db_dir, get_word_lists_dir
@@ -52,8 +52,7 @@ class LanguageManager:
         dlg = QMessageBox(
             QMessageBox.Icon.Question,
             "Anki Dictionary",
-            'Do you really want to remove the language "%s"?\n\nAll settings and dictionaries for it will be removed.'
-            % lang_name,
+            f'Do you really want to remove the language "{lang_name}"?\n\nAll settings and dictionaries for it will be removed.',
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             self.parent,
         )
@@ -74,7 +73,7 @@ class LanguageManager:
             pass
 
         try:
-            path = os.path.join(get_db_dir(), "conjugation", "%s.json" % lang_name)
+            path = os.path.join(get_db_dir(), "conjugation", f"{lang_name}.json")
             os.remove(path)
         except OSError:
             pass
@@ -95,7 +94,7 @@ class LanguageManager:
         dlg = QMessageBox(
             QMessageBox.Icon.Question,
             "Anki Dictionary",
-            'Do you really want to remove the dictionary "%s"?' % dict_display,
+            f'Do you really want to remove the dictionary "{dict_display}"?',
             QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
             self.parent,
         )

--- a/src/anki_dictionary/ui/dialogs/theme_editor.py
+++ b/src/anki_dictionary/ui/dialogs/theme_editor.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 from aqt.qt import (
@@ -16,10 +15,9 @@ from aqt.qt import (
     QWidget,
     pyqtSignal,
 )
-from aqt.utils import showInfo
 
-from ..themes import ThemeColors
 from ...utils.logger import get_logger
+from ..themes import ThemeColors
 
 log = get_logger("theme_editor")
 

--- a/src/anki_dictionary/ui/dialogs/tree_manager_widget.py
+++ b/src/anki_dictionary/ui/dialogs/tree_manager_widget.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aqt.qt import QTreeWidgetItem, Qt
+from aqt.qt import Qt, QTreeWidgetItem
 
 from ...utils.logger import get_logger
 

--- a/src/anki_dictionary/ui/dialogs/wizard.py
+++ b/src/anki_dictionary/ui/dialogs/wizard.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Consolidated wizard components for the Dictionary Addon.
 
@@ -9,12 +8,6 @@ This module contains:
 - Video content fetching for welcome screens
 """
 
-import os
-import re
-from typing import Optional, Tuple, List
-from os.path import dirname, join
-
-import aqt
 from aqt.qt import (
     QDialog,
     QFrame,
@@ -25,13 +18,10 @@ from aqt.qt import (
     QPushButton,
     QSizePolicy,
     QStyle,
+    Qt,
     QVBoxLayout,
     QWidget,
-    Qt,
 )
-from aqt.webview import AnkiWebView
-from aqt.utils import openLink
-from anki.hooks import addHook
 
 # Import config utilities
 from anki_dictionary.utils.config import get_addon_config, save_addon_config
@@ -41,7 +31,7 @@ class MiWizardPage(QWidget):
     """Base class for wizard pages."""
 
     def __init__(self, parent=None):
-        super(MiWizardPage, self).__init__(parent)
+        super().__init__(parent)
 
         self.wizard = None
         self.title = None
@@ -90,7 +80,7 @@ class MiWizard(QDialog):
     """Generic wizard dialog framework."""
 
     def __init__(self, parent=None):
-        super(MiWizard, self).__init__(parent)
+        super().__init__(parent)
 
         self._current_page = None
         self._page_back = {}
@@ -250,11 +240,11 @@ class MiWizard(QDialog):
 
             title = self._current_page.title
             if title:
-                header_text += "<h2>%s</h2>" % title
+                header_text += f"<h2>{title}</h2>"
 
             subtitle = self._current_page.subtitle
             if subtitle:
-                header_text += "<h4>%s</h4>" % subtitle
+                header_text += f"<h4>{subtitle}</h4>"
 
             if header_text:
                 self._header_lbl.setText(header_text)

--- a/src/anki_dictionary/ui/main_window.py
+++ b/src/anki_dictionary/ui/main_window.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Main window and UI management for the Dictionary Addon.
 
@@ -6,34 +5,25 @@ This module contains the main dictionary interface initialization,
 window management, global hotkeys, and UI helper functions.
 """
 
-import os
-import sys
-import re
 import json
-import time
-from typing import Optional, List
-from os.path import dirname, join, exists
-from shutil import copyfile
-from operator import itemgetter
+import os
+import re
 
-from anki.utils import is_win, is_mac, is_lin
+from anki.utils import is_mac, is_win
 from aqt import mw
+
 from ..utils.logger import get_logger
 
 log = get_logger("main_window")
+import aqt.utils
 from aqt.qt import Qt
 from aqt.utils import showInfo
-import aqt.utils
 
-from ..core.dictionary import DictInterface
 from ..core.clip_thread import ClipThread
-from ..ui.themes import *
-from ..ui.dialogs.theme_editor import *
+from ..core.dictionary import DictInterface
 from ..ui.settings.settings_gui import SettingsGui
-from ..utils.common import miInfo, miAsk
-from ..integrations import image_search as duckduckgoimages
-
-from ..utils.paths import get_addon_root, get_templates_dir, get_icons_dir
+from ..utils.common import miInfo
+from ..utils.paths import get_addon_root, get_templates_dir
 
 # Global variables
 addon_path = get_addon_root()
@@ -136,7 +126,7 @@ def getWelcomeScreen():
     """Get welcome screen HTML."""
     htmlPath = os.path.join(get_templates_dir(), "welcome.html")
     try:
-        with open(htmlPath, "r", encoding="utf-8") as fh:
+        with open(htmlPath, encoding="utf-8") as fh:
             file = fh.read()
         return file
     except Exception as e:
@@ -148,7 +138,7 @@ def getMacWelcomeScreen():
     """Get Mac-specific welcome screen HTML."""
     htmlPath = os.path.join(get_templates_dir(), "macwelcome.html")
     try:
-        with open(htmlPath, "r", encoding="utf-8") as fh:
+        with open(htmlPath, encoding="utf-8") as fh:
             file = fh.read()
         return file
     except Exception as e:

--- a/src/anki_dictionary/ui/settings/dict_groups.py
+++ b/src/anki_dictionary/ui/settings/dict_groups.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
 #
 #
-import json
-import sys
-import math
-from anki.hooks import addHook
+import ntpath
+from operator import itemgetter
+from os.path import exists, join
+from shutil import copyfile
+
+from anki.utils import is_lin, is_mac
 from aqt.qt import (
     QAbstractItemView,
     QCheckBox,
@@ -18,32 +19,21 @@ from aqt.qt import (
     QLineEdit,
     QPushButton,
     QRadioButton,
+    Qt,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
-    Qt,
 )
-from aqt.utils import tooltip, showInfo
-from anki.utils import is_mac, is_win, is_lin
-from anki.lang import _
-from aqt.webview import AnkiWebView
-import re
-import os
-from os.path import dirname, join, exists
-from aqt.qt import Qt
-from ...utils.common import miInfo, miAsk
-from ...utils.config import get_addon_config, save_addon_config
 
-from shutil import copyfile
-from operator import itemgetter
-import ntpath
+from ...utils.common import miAsk, miInfo
+from ...utils.config import get_addon_config, save_addon_config
 
 
 class DictGroupEditor(QDialog):
     def __init__(
         self, mw, parent=None, dictionaries=None, group=False, groupName=False
     ):
-        super(DictGroupEditor, self).__init__(parent, Qt.WindowType.Window)
+        super().__init__(parent, Qt.WindowType.Window)
         if dictionaries is None:
             dictionaries = []
         self.mw = mw

--- a/src/anki_dictionary/ui/settings/dict_groups_tab.py
+++ b/src/anki_dictionary/ui/settings/dict_groups_tab.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
 #
 #
 from __future__ import annotations
 
-from typing import Any, Callable, List
+from collections.abc import Callable
+from typing import Any
 
+from anki.utils import is_lin, is_mac, is_win
 from aqt.qt import (
     QAbstractItemView,
     QHeaderView,
@@ -12,10 +13,10 @@ from aqt.qt import (
     QTableWidget,
     QTableWidgetItem,
 )
-from anki.utils import is_mac, is_lin, is_win
-from .dict_groups import DictGroupEditor
+
 from ...utils.common import miAsk
 from ...utils.config import save_addon_config
+from .dict_groups import DictGroupEditor
 
 
 class DictionaryGroupsTab:
@@ -24,7 +25,7 @@ class DictionaryGroupsTab:
         mw: Any,
         parent: Any,
         get_config_callback: Callable[[], dict],
-        get_dictionary_names_callback: Callable[[], List[str]],
+        get_dictionary_names_callback: Callable[[], list[str]],
     ) -> None:
         self.mw = mw
         self.parent = parent

--- a/src/anki_dictionary/ui/settings/export_templates_tab.py
+++ b/src/anki_dictionary/ui/settings/export_templates_tab.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
 #
 #
 from __future__ import annotations
 
-from typing import Any, Callable, List
+from collections.abc import Callable
+from typing import Any
 
+from anki.utils import is_lin, is_mac, is_win
 from aqt.qt import (
     QAbstractItemView,
     QHeaderView,
@@ -12,10 +13,10 @@ from aqt.qt import (
     QTableWidget,
     QTableWidgetItem,
 )
-from anki.utils import is_mac, is_lin, is_win
-from .templates import TemplateEditor
+
 from ...utils.common import miAsk
 from ...utils.config import save_addon_config
+from .templates import TemplateEditor
 
 
 class ExportTemplatesTab:
@@ -24,7 +25,7 @@ class ExportTemplatesTab:
         mw: Any,
         parent: Any,
         get_config_callback: Callable[[], dict],
-        get_dictionary_names_callback: Callable[[], List[str]],
+        get_dictionary_names_callback: Callable[[], list[str]],
     ) -> None:
         self.mw = mw
         self.parent = parent

--- a/src/anki_dictionary/ui/settings/forvo_settings_tab.py
+++ b/src/anki_dictionary/ui/settings/forvo_settings_tab.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any
 
 from aqt.qt import (
     QCheckBox,
@@ -54,14 +54,14 @@ class ForvoSettingsTab(QWidget):
 
         layout.addStretch()
 
-    def load_config(self, config: Dict[str, Any]) -> None:
+    def load_config(self, config: dict[str, Any]) -> None:
         self.forvoEnabled.setChecked(config.get("forvo_enabled", True))
         forvo_lang = config.get("forvo_language", "ja")
         index = self.forvoLanguage.findData(str(forvo_lang))
         if index != -1:
             self.forvoLanguage.setCurrentIndex(index)
 
-    def save_config(self, config: Dict[str, Any]) -> None:
+    def save_config(self, config: dict[str, Any]) -> None:
         config["forvo_enabled"] = self.forvoEnabled.isChecked()
         config["forvo_language"] = self.forvoLanguage.currentData()
 

--- a/src/anki_dictionary/ui/settings/frequency_settings_tab.py
+++ b/src/anki_dictionary/ui/settings/frequency_settings_tab.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict, List
+from typing import Any
 
 from aqt.qt import (
     QCheckBox,
@@ -47,8 +47,8 @@ class FrequencySettingsTab(QWidget):
         self.showLevelLabels = QCheckBox("Display Level Labels")
         self.showLevelLabels.setChecked(True)
 
-        self._list_roles: Dict[str, QComboBox] = {}
-        self._display_name_inputs: Dict[str, QLineEdit] = {}
+        self._list_roles: dict[str, QComboBox] = {}
+        self._display_name_inputs: dict[str, QLineEdit] = {}
 
         self._build_ui()
 
@@ -60,8 +60,8 @@ class FrequencySettingsTab(QWidget):
                 return val
         return name
 
-    def _discover_providers(self) -> Dict[str, WordListProvider]:
-        providers: Dict[str, WordListProvider] = {}
+    def _discover_providers(self) -> dict[str, WordListProvider]:
+        providers: dict[str, WordListProvider] = {}
         try:
             langs = self.mw.miDictDB.getCurrentDbLangs()
             registry = self.mw.miDictDB._registry
@@ -196,7 +196,7 @@ class FrequencySettingsTab(QWidget):
         }
         fname = os.path.basename(filepath)
         try:
-            with open(filepath, "r", encoding="utf-8-sig") as f:
+            with open(filepath, encoding="utf-8-sig") as f:
                 data = json.load(f)
         except (json.JSONDecodeError, OSError):
             result["status"] = "unparseable"
@@ -318,9 +318,9 @@ class FrequencySettingsTab(QWidget):
             self.mw.miDictDB._extra_data_cache.clear()
         self._refresh_installed_files()
 
-    def load_config(self, config: Dict[str, Any]) -> None:
+    def load_config(self, config: dict[str, Any]) -> None:
         self.freqStarChar.setText(config.get("star_char", "\u2605"))
-        thresholds: List[int] = config.get(
+        thresholds: list[int] = config.get(
             "star_thresholds", [1501, 5001, 15001, 30001, 60001]
         )
         self.freqThreshold1.setValue(thresholds[0])
@@ -333,8 +333,8 @@ class FrequencySettingsTab(QWidget):
         self.showRank.setChecked(config.get("show_rank", False))
         self.showLevelLabels.setChecked(config.get("show_level_labels", True))
 
-        provider_roles: Dict[str, str] = config.get("provider_roles", {})
-        word_list_display_names: Dict[str, Dict[str, str]] = config.get(
+        provider_roles: dict[str, str] = config.get("provider_roles", {})
+        word_list_display_names: dict[str, dict[str, str]] = config.get(
             "word_list_display_names", {}
         )
         for key, combo in self._list_roles.items():
@@ -349,7 +349,7 @@ class FrequencySettingsTab(QWidget):
             if display_name:
                 self._display_name_inputs[key].setText(display_name)
 
-    def save_config(self, config: Dict[str, Any]) -> None:
+    def save_config(self, config: dict[str, Any]) -> None:
         config["star_char"] = self.freqStarChar.text()
         config["star_thresholds"] = [
             self.freqThreshold1.value(),
@@ -362,14 +362,14 @@ class FrequencySettingsTab(QWidget):
         config["show_rank"] = self.showRank.isChecked()
         config["show_level_labels"] = self.showLevelLabels.isChecked()
 
-        provider_roles: Dict[str, str] = {}
+        provider_roles: dict[str, str] = {}
         for key, combo in self._list_roles.items():
             role = combo.currentData()
             if role:
                 provider_roles[key] = role
         config["provider_roles"] = provider_roles
 
-        word_list_display_names: Dict[str, Dict[str, str]] = {}
+        word_list_display_names: dict[str, dict[str, str]] = {}
         for key, inp in self._display_name_inputs.items():
             lang, name = key.split("::", 1)
             text = inp.text().strip()

--- a/src/anki_dictionary/ui/settings/llm_settings_tab.py
+++ b/src/anki_dictionary/ui/settings/llm_settings_tab.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from aqt.qt import (
     QCheckBox,
@@ -90,7 +90,7 @@ class LLMSettingsTab(QWidget):
         self.llmStatusLabel.setStyleSheet("font-weight: bold;")
 
         # Dynamic prompt rows
-        self._prompt_rows: List[_PromptRow] = []
+        self._prompt_rows: list[_PromptRow] = []
         self._prompts_container = QVBoxLayout()
         self._prompts_label = QLabel("Prompt Templates:")
         self._prompts_hint = QLabel(
@@ -182,7 +182,7 @@ class LLMSettingsTab(QWidget):
 
     # --- Load / Save ---
 
-    def load_config(self, config: Dict[str, Any]) -> None:
+    def load_config(self, config: dict[str, Any]) -> None:
         self.llmEnabled.setChecked(config.get("llm_enabled", False))
         self.llmApiKey.setText(config.get("llm_api_key", ""))
         self.llmBaseUrl.setText(
@@ -214,7 +214,7 @@ class LLMSettingsTab(QWidget):
                     active = True  # migrate old plain-string format
                 self._add_prompt_row(text, active)
 
-    def save_config(self, config: Dict[str, Any]) -> None:
+    def save_config(self, config: dict[str, Any]) -> None:
         config["llm_enabled"] = self.llmEnabled.isChecked()
         config["llm_api_key"] = self.llmApiKey.text()
         config["llm_base_url"] = self.llmBaseUrl.text()

--- a/src/anki_dictionary/ui/settings/settings_gui.py
+++ b/src/anki_dictionary/ui/settings/settings_gui.py
@@ -1,12 +1,13 @@
-# -*- coding: utf-8 -*-
 #
 #
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from os.path import dirname, join
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any
 
+from anki.utils import is_win
 from aqt.qt import (
     QCheckBox,
     QComboBox,
@@ -23,29 +24,29 @@ from aqt.qt import (
     QScrollArea,
     QShortcut,
     QSpinBox,
+    Qt,
     QTabWidget,
     QUrl,
     QVBoxLayout,
     QWidget,
-    Qt,
 )
-from anki.utils import is_mac, is_win, is_lin
-from .llm_settings_tab import LLMSettingsTab
-from .forvo_settings_tab import ForvoSettingsTab
-from .frequency_settings_tab import FrequencySettingsTab
-from .dict_groups_tab import DictionaryGroupsTab
-from .export_templates_tab import ExportTemplatesTab
-from ...utils.common import miInfo, miAsk
-from ..dialogs.dictionary_manager import DictionaryManagerWidget
+
+from ...utils.common import miAsk
 from ...utils.config import get_addon_config, save_addon_config
 from ...utils.constants import COUNTRY_LIST
+from ..dialogs.dictionary_manager import DictionaryManagerWidget
+from .dict_groups_tab import DictionaryGroupsTab
+from .export_templates_tab import ExportTemplatesTab
+from .forvo_settings_tab import ForvoSettingsTab
+from .frequency_settings_tab import FrequencySettingsTab
+from .llm_settings_tab import LLMSettingsTab
 
 verNumber = "0.1"
 
 
 class SettingsGui(QWidget):
     def __init__(self, mw: Any, path: str, reboot: Callable[[], None]) -> None:
-        super(SettingsGui, self).__init__()
+        super().__init__()
         self.mw = mw
         self.reboot = reboot
         self.addonPath = path
@@ -186,7 +187,7 @@ class SettingsGui(QWidget):
 
         self.llmTab.init_tooltips()
 
-    def getConfig(self) -> Dict[str, Any]:
+    def getConfig(self) -> dict[str, Any]:
         return get_addon_config()
 
     def loadConfig(self) -> None:
@@ -243,7 +244,7 @@ class SettingsGui(QWidget):
     def loadTemplateTable(self) -> None:
         self.exportTemplatesTab.loadTemplateTable()
 
-    def getDictionaryNames(self) -> List[str]:
+    def getDictionaryNames(self) -> list[str]:
         dictList = self.mw.miDictDB.getAllDictsWithLang()
         dictionaryList = []
         for dictionary in dictList:
@@ -377,6 +378,6 @@ class SettingsGui(QWidget):
     def getHTML(self) -> tuple:
         htmlPath = join(self.addonPath, "guide.html")
         url = QUrl.fromLocalFile(htmlPath)
-        with open(htmlPath, "r", encoding="utf-8") as fh:
+        with open(htmlPath, encoding="utf-8") as fh:
             html = fh.read()
         return html, url

--- a/src/anki_dictionary/ui/settings/templates.py
+++ b/src/anki_dictionary/ui/settings/templates.py
@@ -1,10 +1,5 @@
-# -*- coding: utf-8 -*-
 #
 #
-import json
-import sys
-import math
-from anki.hooks import addHook
 from aqt.qt import (
     QAbstractItemView,
     QComboBox,
@@ -15,24 +10,19 @@ from aqt.qt import (
     QLineEdit,
     QPushButton,
     QSize,
+    Qt,
     QTableWidget,
     QTableWidgetItem,
     QVBoxLayout,
-    Qt,
 )
-from aqt.utils import openLink, tooltip, showInfo, askUser
-from anki.utils import is_mac, is_win, is_lin
-from anki.lang import _
-import re
-import os
-from os.path import dirname, join
-from ...utils.common import miInfo, miAsk
+
+from ...utils.common import miInfo
 from ...utils.config import get_addon_config, save_addon_config
 
 
 class TemplateEditor(QDialog):
     def __init__(self, mw, parent=None, dictionaries=None, toEdit=False, tName=False):
-        super(TemplateEditor, self).__init__(parent, Qt.WindowType.Window)
+        super().__init__(parent, Qt.WindowType.Window)
         if dictionaries is None:
             dictionaries = []
         self.setMinimumSize(QSize(400, 0))
@@ -187,9 +177,6 @@ class TemplateEditor(QDialog):
         self.entrySeparator.setText("<br><br>")
 
     def getDictFieldsTable(self):
-        macLin = False
-        if is_mac or is_lin:
-            macLin = True
         dictFields = QTableWidget()
         dictFields.setColumnCount(3)
         tableHeader = dictFields.horizontalHeader()

--- a/src/anki_dictionary/ui/themes.py
+++ b/src/anki_dictionary/ui/themes.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
-from typing import Dict, Optional
 import json
 import os
+from dataclasses import dataclass
+
 from ..utils.logger import get_logger
 
 log = get_logger("themes")
@@ -46,7 +46,7 @@ class ThemeManager:
         self._load_user_themes()
         self._load_active_theme()
 
-    def _load_default_themes(self) -> Dict[str, ThemeColors]:
+    def _load_default_themes(self) -> dict[str, ThemeColors]:
         return {
             "light": ThemeColors(
                 header_background="#FFFFFF",
@@ -182,7 +182,7 @@ class ThemeManager:
         """Load user-defined themes from themes.json"""
         if os.path.exists(self.themes_file):
             try:
-                with open(self.themes_file, "r") as f:
+                with open(self.themes_file) as f:
                     user_themes = json.load(f)
                 for name, colors in user_themes.items():
                     self.themes[name] = ThemeColors(**colors)
@@ -193,7 +193,7 @@ class ThemeManager:
         """Load the active theme from active.json"""
         if os.path.exists(self.active_theme_file):
             try:
-                with open(self.active_theme_file, "r") as f:
+                with open(self.active_theme_file) as f:
                     active_theme_data = json.load(f)
 
                 # Remove any extra fields that aren't part of ThemeColors
@@ -271,7 +271,7 @@ class ThemeManager:
         self.themes[name] = colors
         self._save_themes()
 
-    def save_active_theme(self, colors: ThemeColors, theme_name: Optional[str] = None):
+    def save_active_theme(self, colors: ThemeColors, theme_name: str | None = None):
         self.themes["active"] = colors
         self._save_themes()
         os.makedirs(os.path.dirname(self.active_theme_file), exist_ok=True)
@@ -288,7 +288,7 @@ class ThemeManager:
             themes_dict = {name: vars(colors) for name, colors in self.themes.items()}
             json.dump(themes_dict, f, indent=2)
 
-    def get_css(self, theme_name: Optional[str] = None) -> str:
+    def get_css(self, theme_name: str | None = None) -> str:
         """Generate CSS for the current theme"""
         requested_theme = theme_name or self.current_theme
 
@@ -358,9 +358,7 @@ class ThemeManager:
         }}
         """
 
-    def get_qt_styles(
-        self, theme_name: Optional[str] = None, is_mac: bool = False
-    ) -> str:
+    def get_qt_styles(self, theme_name: str | None = None, is_mac: bool = False) -> str:
         """Generate Qt styles for the current theme"""
         requested_theme = theme_name or self.current_theme
 
@@ -444,7 +442,7 @@ class ThemeManager:
             """
 
     def get_combo_style(
-        self, theme_name: Optional[str] = None, is_mac: bool = False
+        self, theme_name: str | None = None, is_mac: bool = False
     ) -> str:
         """Generate Qt styles for QComboBox"""
         requested_theme = theme_name or self.current_theme

--- a/src/anki_dictionary/utils/common.py
+++ b/src/anki_dictionary/utils/common.py
@@ -1,18 +1,19 @@
-# -*- coding: utf-8 -*-
 #
 
-import aqt
-from aqt.qt import QIcon, QMessageBox, QWidget
-from typing import Any
-import os
 import contextlib
+import os
 from collections.abc import Generator
+from typing import Any
+
+import aqt
 import urllib3.util.connection as connection
+from aqt.qt import QIcon, QMessageBox, QWidget
+
 from .paths import get_icons_dir
 
 
 @contextlib.contextmanager
-def prefer_ipv4() -> Generator[None, None, None]:
+def prefer_ipv4() -> Generator[None]:
     old_has_ipv6 = getattr(connection, "HAS_IPV6", False)
     try:
         connection.HAS_IPV6 = False

--- a/src/anki_dictionary/utils/config.py
+++ b/src/anki_dictionary/utils/config.py
@@ -10,7 +10,7 @@ import os
 import sys
 from typing import Any
 
-from aqt import mw
+import aqt
 
 from .logger import get_logger
 from .paths import get_addon_name, get_addon_root
@@ -48,18 +48,18 @@ def get_addon_config() -> dict[str, Any]:
 
     # Fallback 1: try to get config from mw.AnkiDictConfig (legacy compatibility)
     if (
-        hasattr(mw, "__dict__")
-        and "AnkiDictConfig" in mw.__dict__
-        and mw.__dict__["AnkiDictConfig"] is not None
+        hasattr(aqt.mw, "__dict__")
+        and "AnkiDictConfig" in aqt.mw.__dict__
+        and aqt.mw.__dict__["AnkiDictConfig"] is not None
     ):
-        config_dict = mw.__dict__["AnkiDictConfig"]
+        config_dict = aqt.mw.__dict__["AnkiDictConfig"]
         if isinstance(config_dict, dict):
             return config_dict
 
     # Fallback 2: try to get config using correct addon name
     addon_name = get_addon_name()
     try:
-        config = mw.addonManager.getConfig(addon_name)
+        config = aqt.mw.addonManager.getConfig(addon_name)
         if config:
             return config
     except Exception:
@@ -139,7 +139,7 @@ def refresh_anki_dict_config(
         try:
             # We don't want to pass the config object as terms to resetConfiguration
             # just trigger a reload of settings and groups.
-            mw.ankiDictionary.resetConfiguration()  # ty:ignore[call-non-callable]
+            aqt.mw.ankiDictionary.resetConfiguration()  # ty:ignore[call-non-callable]
         except Exception as e:
             logger.error(f"Error refreshing dictionary configuration: {e}")
 

--- a/src/anki_dictionary/utils/config.py
+++ b/src/anki_dictionary/utils/config.py
@@ -122,19 +122,19 @@ def refresh_anki_dict_config(
     """
     if config is not None:
         # Direct config provided - use it
-        if hasattr(mw, "__dict__"):
-            mw.__dict__["AnkiDictConfig"] = config
+        if hasattr(aqt.mw, "__dict__"):
+            aqt.mw.__dict__["AnkiDictConfig"] = config
     else:
         # Re-load from disk/state
         config = get_addon_config()
-        if hasattr(mw, "__dict__"):
-            mw.__dict__["AnkiDictConfig"] = config
+        if hasattr(aqt.mw, "__dict__"):
+            aqt.mw.__dict__["AnkiDictConfig"] = config
 
     # If dictionary exists and is visible, update its configuration
     if (
-        hasattr(mw, "ankiDictionary")
-        and mw.ankiDictionary
-        and hasattr(mw.ankiDictionary, "resetConfiguration")
+        hasattr(aqt.mw, "ankiDictionary")
+        and aqt.mw.ankiDictionary
+        and hasattr(aqt.mw.ankiDictionary, "resetConfiguration")
     ):
         try:
             # We don't want to pass the config object as terms to resetConfiguration
@@ -174,13 +174,13 @@ def save_addon_config(config: dict[str, Any]) -> bool:
         logger.debug("Could not save config to addon state")
 
     # 2. Update legacy location
-    if hasattr(mw, "__dict__"):
-        mw.__dict__["AnkiDictConfig"] = config
+    if hasattr(aqt.mw, "__dict__"):
+        aqt.mw.__dict__["AnkiDictConfig"] = config
 
     # 3. Save to Anki's config manager
     try:
         addon_name = get_addon_name()
-        mw.addonManager.writeConfig(addon_name, config)
+        aqt.mw.addonManager.writeConfig(addon_name, config)
     except Exception:
         return False
 

--- a/src/anki_dictionary/utils/config.py
+++ b/src/anki_dictionary/utils/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Configuration utilities for the Anki Dictionary Addon.
 
@@ -6,20 +5,20 @@ This module provides safe access to addon configuration that works
 regardless of the module path or Anki version.
 """
 
+import json
 import os
 import sys
-import json
-from typing import Any, Dict, Optional
+from typing import Any
+
 from aqt import mw
 
-
-from .paths import get_addon_root, get_addon_name
 from .logger import get_logger
+from .paths import get_addon_name, get_addon_root
 
 logger = get_logger(__name__.split(".")[-1])
 
 
-def get_addon_config() -> Dict[str, Any]:
+def get_addon_config() -> dict[str, Any]:
     """
     Get addon configuration safely.
 
@@ -71,7 +70,7 @@ def get_addon_config() -> Dict[str, Any]:
         addon_root = get_addon_root()
         config_path = os.path.join(addon_root, "config.json")
         if os.path.exists(config_path):
-            with open(config_path, "r", encoding="utf-8") as f:
+            with open(config_path, encoding="utf-8") as f:
                 return json.load(f)
     except Exception:
         logger.debug("Could not load config from config.json")
@@ -112,7 +111,7 @@ def get_addon_config() -> Dict[str, Any]:
 
 
 def refresh_anki_dict_config(
-    config: Optional[Dict[str, Any]] = None, force: bool = False
+    config: dict[str, Any] | None = None, force: bool = False
 ) -> None:
     """
     Refresh the addon configuration and update the dictionary window if it exists.
@@ -145,7 +144,7 @@ def refresh_anki_dict_config(
             logger.error(f"Error refreshing dictionary configuration: {e}")
 
 
-def save_addon_config(config: Dict[str, Any]) -> bool:
+def save_addon_config(config: dict[str, Any]) -> bool:
     """
     Save addon configuration safely.
 

--- a/src/anki_dictionary/utils/constants.py
+++ b/src/anki_dictionary/utils/constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Constants used across the Anki Dictionary Addon.
 """
@@ -353,9 +352,10 @@ COUNTRY_TO_DDG = {
 
 # Load Forvo languages from assets
 def _load_forvo_languages():
-    import os
     import json
+    import os
     from os.path import dirname, join
+
     from .logger import get_logger
 
     log = get_logger("constants")
@@ -365,7 +365,7 @@ def _load_forvo_languages():
         addon_path = dirname(dirname(dirname(dirname(__file__))))
         langs_path = join(addon_path, "assets", "forvo_languages.json")
         if os.path.exists(langs_path):
-            with open(langs_path, "r", encoding="utf-8") as f:
+            with open(langs_path, encoding="utf-8") as f:
                 return json.load(f)
     except Exception as e:
         log.error(f"Error loading Forvo languages: {e}")

--- a/src/anki_dictionary/utils/history.py
+++ b/src/anki_dictionary/utils/history.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
 #
 
-import json
 
+import datetime
+
+from anki.utils import is_mac
 from aqt.qt import (
     QAbstractItemView,
     QAbstractTableModel,
@@ -14,28 +15,26 @@ from aqt.qt import (
     QPalette,
     QPushButton,
     QShortcut,
+    Qt,
     QTableView,
     QVBoxLayout,
     QWidget,
-    Qt,
 )
-from aqt.utils import askUser, showInfo
-import datetime
-from .common import miInfo, miAsk
-from anki.utils import strip_html, is_win, is_mac, is_lin
+
+from .common import miAsk
 
 
 class HistoryModel(QAbstractTableModel):
     def __init__(self, history, parent=None):
-        super(HistoryModel, self).__init__(parent)
+        super().__init__(parent)
         self.history = history
         self.dictInt = parent
         self.justTerms = [item[0] for item in history]
 
-    def rowCount(self, index=QModelIndex()):  # ty:ignore[invalid-method-override]
+    def rowCount(self, index=QModelIndex()):  # noqa: B008  # ty:ignore[invalid-method-override]
         return len(self.history)
 
-    def columnCount(self, index=QModelIndex()):  # ty:ignore[invalid-method-override]
+    def columnCount(self, index=QModelIndex()):  # noqa: B008  # ty:ignore[invalid-method-override]
         return 2
 
     def data(self, index, role=Qt.ItemDataRole.DisplayRole):
@@ -62,12 +61,17 @@ class HistoryModel(QAbstractTableModel):
         return None
 
     def insertRows(
-        self, position=False, rows=1, index=QModelIndex(), term=False, date=False
+        self,
+        position=False,
+        rows=1,
+        index=QModelIndex(),  # noqa: B008
+        term=False,
+        date=False,
     ):  # ty:ignore[invalid-method-override]
         if not position:
             position = self.rowCount()
         self.beginInsertRows(QModelIndex(), position, position)
-        for row in range(rows):
+        for _row in range(rows):
             if term and date:
                 if term in self.justTerms:
                     index = self.justTerms.index(term)
@@ -79,7 +83,7 @@ class HistoryModel(QAbstractTableModel):
         self.dictInt.saveHistory()  # ty:ignore[unresolved-attribute]
         return True
 
-    def removeRows(self, position, rows=1, index=QModelIndex()):  # ty:ignore[invalid-method-override]
+    def removeRows(self, position, rows=1, index=QModelIndex()):  # noqa: B008  # ty:ignore[invalid-method-override]
         self.beginRemoveRows(QModelIndex(), position, position + rows - 1)
         del self.history[position : position + rows]
         self.endRemoveRows()
@@ -89,7 +93,7 @@ class HistoryModel(QAbstractTableModel):
 
 class HistoryBrowser(QWidget):
     def __init__(self, historyModel, parent):
-        super(HistoryBrowser, self).__init__(parent, Qt.WindowType.Window)
+        super().__init__(parent, Qt.WindowType.Window)
         self.history_model = None
         self.setAutoFillBackground(True)
         self.resize(300, 200)

--- a/src/anki_dictionary/utils/logger.py
+++ b/src/anki_dictionary/utils/logger.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Logging utility for the Anki Dictionary Addon.
 """
@@ -6,6 +5,7 @@ Logging utility for the Anki Dictionary Addon.
 import logging
 import os
 from logging.handlers import TimedRotatingFileHandler
+
 from aqt import mw
 
 from .paths import get_addon_root

--- a/src/anki_dictionary/utils/media_manager.py
+++ b/src/anki_dictionary/utils/media_manager.py
@@ -6,7 +6,6 @@ import re
 import shutil
 import time
 from os.path import exists, join
-from typing import Optional, Tuple
 from urllib.request import Request, urlopen
 
 from aqt.qt import QImage, QSize, Qt
@@ -120,7 +119,7 @@ def scale_image(
         return False
 
 
-def copy_to_media(source: str, filename: str, media_dir: str) -> Optional[str]:
+def copy_to_media(source: str, filename: str, media_dir: str) -> str | None:
     dest = join(media_dir, filename)
     if exists(source) and not exists(dest):
         try:
@@ -134,7 +133,7 @@ def copy_to_media(source: str, filename: str, media_dir: str) -> Optional[str]:
 
 def copy_to_temp(
     source: str, temp_dir: str, ext: str = "mp3"
-) -> Tuple[Optional[str], Optional[str]]:
+) -> tuple[str | None, str | None]:
     try:
         if not exists(source):
             return None, None
@@ -169,7 +168,7 @@ def remove_file(path: str) -> None:
         logger.warning(f"Failed to remove {path}: {e}")
 
 
-def load_image_from_url(url: str) -> Optional[QImage]:
+def load_image_from_url(url: str) -> QImage | None:
     try:
         if url.startswith("data:"):
             _, encoded = url.split(",", 1)

--- a/src/anki_dictionary/utils/paths.py
+++ b/src/anki_dictionary/utils/paths.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Path utilities for the Anki Dictionary Addon.
 """

--- a/src/anki_dictionary/web/config.py
+++ b/src/anki_dictionary/web/config.py
@@ -1,5 +1,7 @@
 import json
+
 from anki.httpclient import HttpClient
+
 from ..utils.common import prefer_ipv4
 
 DEFAULT_SERVER = "https://github.com/Alexander-Nilsson/dictionaries/raw/main"

--- a/src/anki_dictionary/web/icons.py
+++ b/src/anki_dictionary/web/icons.py
@@ -1,16 +1,13 @@
-# -*- coding: utf-8 -*-
 """
 Utility for handling icons and base64 encoding.
 """
 
-import os
 import base64
+import os
 from functools import lru_cache
-from os.path import join, dirname
 
-
-from ..utils.paths import get_icons_dir
 from ..utils.logger import get_logger
+from ..utils.paths import get_icons_dir
 
 logger = get_logger(__name__.split(".")[-1])
 

--- a/src/anki_dictionary/web/installer.py
+++ b/src/anki_dictionary/web/installer.py
@@ -1,3 +1,10 @@
+import io
+import json
+import os
+import zipfile
+
+import aqt
+from anki.httpclient import HttpClient
 from aqt.qt import (
     QCheckBox,
     QHBoxLayout,
@@ -8,26 +15,19 @@ from aqt.qt import (
     QPlainTextEdit,
     QProgressBar,
     QPushButton,
+    Qt,
     QTextCursor,
     QTextEdit,
     QThread,
     QTreeWidget,
     QTreeWidgetItem,
     QVBoxLayout,
-    Qt,
     pyqtSignal,
 )
-from anki.httpclient import HttpClient
-import json
-import io
-import os
-import aqt
-import zipfile
-
 
 from ..ui.dialogs.wizard import MiWizard, MiWizardPage
-from . import config as webConfig
 from ..utils.common import prefer_ipv4
+from . import config as webConfig
 
 addon_path = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -101,7 +101,7 @@ def _validate_word_list_data(
 
 class NoAutoSelectLineEdit(QLineEdit):
     def focusInEvent(self, e):  # ty:ignore[invalid-method-override]
-        super(NoAutoSelectLineEdit, self).focusInEvent(e)
+        super().focusInEvent(e)
         self.deselect()
 
 
@@ -109,7 +109,7 @@ class DictionaryWebInstallWizard(MiWizard):
     INITIAL_SIZE = (600, 400)
 
     def __init__(self, force_lang=None):
-        super(DictionaryWebInstallWizard, self).__init__()
+        super().__init__()
 
         self.dictionary_force_lang = force_lang
 
@@ -121,9 +121,7 @@ class DictionaryWebInstallWizard(MiWizard):
         server_add_page = self.add_page(ServerAskPage(self))
         dict_select_page = self.add_page(DictionarySelectPage(self), server_add_page)
         dict_confirm_page = self.add_page(DictionaryConfirmPage(self), dict_select_page)
-        dict_install_page = self.add_page(
-            DictionaryInstallPage(self), dict_confirm_page
-        )
+        self.add_page(DictionaryInstallPage(self), dict_confirm_page)
 
         self.resize(*self.INITIAL_SIZE)
 
@@ -135,7 +133,7 @@ class DictionaryWebInstallWizard(MiWizard):
 
 class ServerAskPage(MiWizardPage):
     def __init__(self, wizard):
-        super(ServerAskPage, self).__init__(wizard)
+        super().__init__(wizard)
         self.wizard = wizard
 
         self.title = "Select Dictionary Server"
@@ -186,9 +184,8 @@ class ServerAskPage(MiWizardPage):
             QMessageBox.information(
                 self,
                 "Anki Dictionary",
-                'The server "%s" is not reachable.\n\n'
-                "Make sure you are connected to the internet and the url you entered is valid."
-                % server_url_usr,
+                f'The server "{server_url_usr}" is not reachable.\n\n'
+                "Make sure you are connected to the internet and the url you entered is valid.",
             )
             return False
 
@@ -200,7 +197,7 @@ class ServerAskPage(MiWizardPage):
 
 class DictionarySelectPage(MiWizardPage):
     def __init__(self, wizard):
-        super(DictionarySelectPage, self).__init__(wizard)
+        super().__init__(wizard)
         self.wizard = wizard
 
         self.title = "Select the dictionaries you want to install"
@@ -263,7 +260,7 @@ class DictionarySelectPage(MiWizardPage):
             language = lang_item.data(0, Qt.ItemDataRole.UserRole + 0)  # ty:ignore[unresolved-attribute]
             dictionaries = []
 
-            def scan_tree(item):
+            def scan_tree(item, dicts=dictionaries):
                 for di in range(item.childCount()):
                     dict_item = item.child(di)
                     dictionary = dict_item.data(0, Qt.ItemDataRole.UserRole + 1)
@@ -271,13 +268,13 @@ class DictionarySelectPage(MiWizardPage):
                         try:
                             # Try the new way
                             if dict_item.checkState(0) == Qt.CheckState.Checked:
-                                dictionaries.append(dictionary)
+                                dicts.append(dictionary)
                         except AttributeError:
                             # Fallback for older versions
                             if dict_item.checkState(0) == Qt.Checked:  # ty:ignore[unresolved-attribute]
-                                dictionaries.append(dictionary)
+                                dicts.append(dictionary)
                     else:
-                        scan_tree(dict_item)
+                        scan_tree(dict_item, dicts)
 
             scan_tree(lang_item)
 
@@ -408,7 +405,7 @@ class DictionarySelectPage(MiWizardPage):
 
 class DictionaryConfirmPage(MiWizardPage):
     def __init__(self, wizard, can_select_none=False):
-        super(DictionaryConfirmPage, self).__init__(wizard)
+        super().__init__(wizard)
         self.wizard = wizard
         self.can_select_none = can_select_none
 
@@ -426,7 +423,6 @@ class DictionaryConfirmPage(MiWizardPage):
 
     def on_show(self, is_next, is_prev):  # ty:ignore[invalid-method-override]
         install_index = getattr(self.wizard, "dictionary_install_index", [])
-        install_conj = getattr(self.wizard, "dictionary_install_conjugation", False)
         install_word_lists = getattr(
             self.wizard, "dictionary_install_word_lists", False
         )
@@ -555,7 +551,7 @@ class DictionaryInstallPage(MiWizardPage):
             for l in self.install_index:
                 num_dicts += len(l.get("dictionaries", []))
 
-            self.log_update.emit("Installing %d dictionaries..." % num_dicts)
+            self.log_update.emit(f"Installing {num_dicts} dictionaries...")
 
             word_lists_path = os.path.join(addon_path, "user_files", "db", "word_lists")
             os.makedirs(word_lists_path, exist_ok=True)
@@ -594,7 +590,7 @@ class DictionaryInstallPage(MiWizardPage):
                             "level": "word list",
                         }.get(wl_type, "word list")
                         self.log_update.emit(
-                            "Installing %s %s (%s)..." % (lname, wl_name, type_label)
+                            f"Installing {lname} {wl_name} ({type_label})..."
                         )
                         dl_resp = self.fetch_data(client, wl_url)
                         if dl_resp.status_code == 200:
@@ -614,7 +610,7 @@ class DictionaryInstallPage(MiWizardPage):
                                         data = z.read(json_files[0])
                                 except Exception as e:
                                     self.log_update.emit(
-                                        " ERROR: Failed to unzip: %s" % str(e)
+                                        f" ERROR: Failed to unzip: {str(e)}"
                                     )
 
                             validated = _validate_word_list_data(
@@ -629,14 +625,14 @@ class DictionaryInstallPage(MiWizardPage):
                             slug = "".join(c for c in slug if c.isalnum() or c == "_")
                             lang_part = lname.replace(" ", "_")
                             type_tag = ".freq" if wl_type == "frequency" else ".level"
-                            filename = "%s_%s%s.json" % (lang_part, slug, type_tag)
+                            filename = f"{lang_part}_{slug}{type_tag}.json"
                             dst_path = os.path.join(word_lists_path, filename)
                             with open(dst_path, "wb") as f:
                                 f.write(validated)
-                            self.log_update.emit(" Installed as %s" % filename)
+                            self.log_update.emit(f" Installed as {filename}")
                         else:
                             self.log_update.emit(
-                                " ERROR: Download failed (%d)." % dl_resp.status_code
+                                f" ERROR: Download failed ({dl_resp.status_code})."
                             )
 
                 # Install conjugation data
@@ -652,9 +648,7 @@ class DictionaryInstallPage(MiWizardPage):
                     for c_info in curls:
                         cname = c_info["name"]
                         curl = self.construct_url(c_info["url"])
-                        self.log_update.emit(
-                            "Installing %s %s data..." % (lname, cname)
-                        )
+                        self.log_update.emit(f"Installing {lname} {cname} data...")
                         dl_resp = self.fetch_data(client, curl)
                         if dl_resp.status_code == 200:
                             chunks = []
@@ -663,13 +657,13 @@ class DictionaryInstallPage(MiWizardPage):
                                     chunks.append(chunk)
                             data = b"".join(chunks)
 
-                            dst_path = os.path.join(conj_path, "%s.json" % lname)
+                            dst_path = os.path.join(conj_path, f"{lname}.json")
                             with open(dst_path, "wb") as f:
                                 f.write(data)
                             break
                         else:
                             self.log_update.emit(
-                                " ERROR: Download failed (%d)." % dl_resp.status_code
+                                f" ERROR: Download failed ({dl_resp.status_code})."
                             )
 
                 # Install dictionaries
@@ -680,15 +674,15 @@ class DictionaryInstallPage(MiWizardPage):
                     dname = d.get("name")
 
                     if aqt.mw.miDictDB.dictExists(dname, lname):  # ty:ignore[unresolved-attribute]
-                        self.log_update.emit("Skipping %s (already installed)." % dname)
+                        self.log_update.emit(f"Skipping {dname} (already installed).")
                         update_dict_progress(1.0)
                         num_installed += 1
                         continue
 
                     durl = self.construct_url(d.get("url"))
 
-                    self.log_update.emit("Installing %s..." % dname)
-                    self.log_update.emit(" Downloading %s..." % durl)
+                    self.log_update.emit(f"Installing {dname}...")
+                    self.log_update.emit(f" Downloading {durl}...")
                     dl_resp = self.fetch_data(client, durl)
 
                     if dl_resp.status_code == 200:
@@ -709,10 +703,10 @@ class DictionaryInstallPage(MiWizardPage):
                                 parent=self.wizard,
                             )
                         except ValueError as e:
-                            self.log_update.emit(" ERROR: %s" % str(e))
+                            self.log_update.emit(f" ERROR: {str(e)}")
                     else:
                         self.log_update.emit(
-                            " ERROR: Download failed (%d)." % dl_resp.status_code
+                            f" ERROR: Download failed ({dl_resp.status_code})."
                         )
 
                     update_dict_progress(1.0)
@@ -725,7 +719,7 @@ class DictionaryInstallPage(MiWizardPage):
             self.log_update.emit("All done.")
 
     def __init__(self, wizard, is_last_page=True):
-        super(DictionaryInstallPage, self).__init__(wizard)
+        super().__init__(wizard)
         self.wizard = wizard
         self.is_last_page = is_last_page
 

--- a/src/anki_dictionary/web/installer.py
+++ b/src/anki_dictionary/web/installer.py
@@ -533,7 +533,7 @@ class DictionaryInstallPage(MiWizardPage):
                 return client.session.get(quoted_url, timeout=60, stream=True)
 
         def run(self):
-            from ..ui.dialogs.dictionary_manager import importDict
+            from ..ui.dialogs.dict_import import importDict
 
             client = HttpClient()
 
@@ -698,7 +698,7 @@ class DictionaryInstallPage(MiWizardPage):
                         try:
                             importDict(
                                 lname,
-                                io.BytesIO(ddata),  # ty:ignore[invalid-argument-type]
+                                io.BytesIO(ddata),
                                 dname,
                                 parent=self.wizard,
                             )

--- a/src/anki_dictionary/web/windows.py
+++ b/src/anki_dictionary/web/windows.py
@@ -2,6 +2,9 @@ import io
 import os
 import zipfile
 from enum import Enum
+
+import aqt
+from anki.httpclient import HttpClient
 from aqt.qt import (
     QDialog,
     QIcon,
@@ -10,14 +13,12 @@ from aqt.qt import (
     QListWidgetItem,
     QMessageBox,
     QPushButton,
-    QVBoxLayout,
     Qt,
+    QVBoxLayout,
 )
-from anki.httpclient import HttpClient
-import aqt
-from ..utils.common import prefer_ipv4
 
-from ..utils.paths import get_icons_dir, get_db_dir, get_word_lists_dir
+from ..utils.common import prefer_ipv4
+from ..utils.paths import get_db_dir, get_icons_dir, get_word_lists_dir
 from . import config as webConfig
 
 
@@ -29,7 +30,7 @@ class FreqConjWebWindow(QDialog):
     MIN_SIZE = (400, 400)
 
     def __init__(self, dst_lang, index_data, mode):
-        super(FreqConjWebWindow, self).__init__()
+        super().__init__()
         self.dst_lang = dst_lang
         self.mode = mode
         self.mode_str = "word_lists" if self.mode == self.Mode.Freq else "conjugation"
@@ -41,7 +42,7 @@ class FreqConjWebWindow(QDialog):
         self.setLayout(lyt)
 
         lbl = QLabel(
-            "Select the language you want to download %s data from" % self.mode_str
+            f"Select the language you want to download {self.mode_str} data from"
         )
         lbl.setWordWrap(True)
         lyt.addWidget(lbl)
@@ -124,7 +125,7 @@ class FreqConjWebWindow(QDialog):
 
         if resp is None or resp.status_code != 200:
             QMessageBox.information(
-                self, self.windowTitle(), "Downloading %s data failed." % self.mode_str
+                self, self.windowTitle(), f"Downloading {self.mode_str} data failed."
             )
             return
 
@@ -157,10 +158,10 @@ class FreqConjWebWindow(QDialog):
             slug = list_name.lower().replace(" ", "_")
             slug = "".join(c for c in slug if c.isalnum() or c == "_")
             lang_part = self.dst_lang.replace(" ", "_")
-            filename = "%s_%s.json" % (lang_part, slug)
+            filename = f"{lang_part}_{slug}.json"
         else:
             lang_part = self.dst_lang.replace(" ", "_")
-            filename = "%s.json" % lang_part
+            filename = f"{lang_part}.json"
 
         dst_path = os.path.join(dir_path, filename)
 
@@ -176,9 +177,9 @@ class FreqConjWebWindow(QDialog):
             aqt.mw.miDictDB._extra_data_cache.pop(self.dst_lang, None)  # ty:ignore[unresolved-attribute]
 
         if self.mode == self.Mode.Freq:
-            msg = 'Imported data as "%s" for "%s".' % (filename, self.dst_lang)
+            msg = f'Imported data as "{filename}" for "{self.dst_lang}".'
         else:
-            msg = 'Imported conjugation data for "%s".' % self.dst_lang
+            msg = f'Imported conjugation data for "{self.dst_lang}".'
         QMessageBox.information(self, self.windowTitle(), msg)
 
         self.accept()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -82,6 +82,7 @@ def headless_anki_collection():
     """
     import shutil
     import tempfile
+
     from anki.collection import Collection
 
     base_dir = tempfile.mkdtemp(prefix="anki_dict_int_")

--- a/tests/integration/test_addon_loads.py
+++ b/tests/integration/test_addon_loads.py
@@ -4,11 +4,8 @@ These tests use a headless ``anki.collection.Collection`` (no Qt GUI needed)
 and verify that our addon's core modules can work with a live Anki database.
 """
 
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 class TestCollectionBasics:
@@ -44,8 +41,9 @@ class TestAddonDatabase:
     """Test DictDB against a real SQLite database (without mocking)."""
 
     def test_db_creation(self, headless_anki_collection):
-        import aqt
         from unittest.mock import MagicMock
+
+        import aqt
 
         aqt.mw = MagicMock()
         aqt.mw.pm.addonFolder.return_value = headless_anki_collection.base
@@ -63,9 +61,9 @@ class TestAddonImports:
 
     def test_core_modules_importable(self):
         import anki_dictionary.core.database  # noqa: F401
-        import anki_dictionary.utils.paths  # noqa: F401
         import anki_dictionary.utils.config  # noqa: F401
         import anki_dictionary.utils.constants  # noqa: F401
+        import anki_dictionary.utils.paths  # noqa: F401
 
     def test_utils_importable(self):
         import anki_dictionary.utils.common  # noqa: F401
@@ -189,6 +187,7 @@ class TestDictInterface:
         from unittest.mock import MagicMock
 
         import aqt
+
         import anki_dictionary.core.dictionary as _d
 
         aqt.mw = MagicMock()  # ensureWidgetInScreenBoundaries accesses aqt.mw.progress

--- a/tests/integration/test_smoke_pytest_anki.py
+++ b/tests/integration/test_smoke_pytest_anki.py
@@ -83,7 +83,9 @@ def test_history_browser_set_colors_uses_theme_manager(
     load_theme_color() method.  Regression test: the parent (DictInterface)
     has theme_manager but not load_theme_color."""
     from unittest.mock import MagicMock
+
     from PyQt6.QtWidgets import QWidget
+
     from anki_dictionary.ui.themes import ThemeColors
     from anki_dictionary.utils.history import HistoryBrowser, HistoryModel
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -5,11 +5,10 @@ Test runner for Anki Dictionary Addon
 This script runs all tests and provides a comprehensive test report.
 """
 
-import unittest
 import sys
-import os
-from pathlib import Path
 import time
+import unittest
+from pathlib import Path
 
 # Add current directory and project root to path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -58,12 +57,12 @@ def discover_and_run_tests():
 
         if result.failures:
             print("\n🔴 FAILURES:")
-            for test, traceback in result.failures:
+            for test, _traceback in result.failures:
                 print(f"  - {test}")
 
         if result.errors:
             print("\n💥 ERRORS:")
-            for test, traceback in result.errors:
+            for test, _traceback in result.errors:
                 print(f"  - {test}")
 
         if skipped_count:
@@ -114,7 +113,7 @@ def check_test_dependencies():
             sys.path.insert(0, str(src_path))
 
         # Try to import basic addon modules
-        import anki_dictionary
+        import anki_dictionary  # noqa: F401
 
         print("✅ Main module can be imported")
     except ImportError as e:

--- a/tests/test_addon_structure.py
+++ b/tests/test_addon_structure.py
@@ -3,8 +3,8 @@
 Tests for the main Anki Dictionary Addon functionality
 """
 
-import unittest
 import sys
+import unittest
 from pathlib import Path
 
 # Add src directory to path for imports
@@ -70,7 +70,7 @@ class TestAddonBasics(unittest.TestCase):
         )
         if not config_path.exists():
             self.skipTest("Build directory does not exist - run build first")
-        with open(config_path, "r") as f:
+        with open(config_path) as f:
             config = json.load(f)
 
         # Should be a dictionary

--- a/tests/test_all_dictionaries.py
+++ b/tests/test_all_dictionaries.py
@@ -1,14 +1,12 @@
-import json
-import requests
 import io
 import os
 import sys
 import tempfile
-import unittest
-from unittest.mock import MagicMock, patch
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 pytestmark = pytest.mark.network
 
@@ -17,10 +15,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 import aqt
-from unittest.mock import MagicMock
+
 from anki_dictionary.core.database import DictDB
-from scripts.create_empty_db import create_empty_database
 from anki_dictionary.ui.dialogs.dictionary_manager import importDict
+from scripts.create_empty_db import create_empty_database
 
 aqt.mw = MagicMock()
 
@@ -102,7 +100,7 @@ def test_all():
                     print(f"  SUCCESS: {count} entries.")
                     results.append({"name": name, "status": "OK", "count": count})
                 else:
-                    print(f"  FAIL: No entries.")
+                    print("  FAIL: No entries.")
                     results.append(
                         {"name": name, "status": "FAIL", "error": "No entries imported"}
                     )

--- a/tests/test_card_exporter.py
+++ b/tests/test_card_exporter.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import atexit
 import sys
 import unittest
-from unittest.mock import MagicMock, patch
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -192,8 +191,8 @@ if _src not in sys.path:
     sys.path.insert(0, _src)
 
 # Now safe to import addon modules
-from anki_dictionary.exporters.html_cleaner import HtmlCleaner  # noqa: E402
 from anki_dictionary.exporters.card_exporter import CardExporter  # noqa: E402
+from anki_dictionary.exporters.html_cleaner import HtmlCleaner  # noqa: E402
 
 
 # ===================================================================

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,7 +20,7 @@ class TestConfig(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
 
-    @patch("anki_dictionary.utils.config.mw")
+    @patch("anki_dictionary.utils.config.aqt.mw")
     @patch("anki_dictionary.utils.config.get_addon_root")
     def test_get_addon_config_fallback_defaults(self, mock_root, mock_mw):
         mock_root.return_value = "/fake/addon"
@@ -36,7 +36,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(result["currentGroup"], "All")
         self.assertEqual(result["forvo_enabled"], True)
 
-    @patch("anki_dictionary.utils.config.mw")
+    @patch("anki_dictionary.utils.config.aqt.mw")
     @patch("anki_dictionary.utils.config.get_addon_root")
     def test_save_and_refresh_config(self, mock_root, mock_mw):
         mock_root.return_value = "/fake/addon"
@@ -46,7 +46,7 @@ class TestConfig(unittest.TestCase):
         result = save_addon_config(config)
         self.assertTrue(result)
 
-    @patch("anki_dictionary.utils.config.mw")
+    @patch("anki_dictionary.utils.config.aqt.mw")
     def test_refresh_config_with_dict(self, mock_mw):
         mock_mw.ankiDictionary = MagicMock()
         mock_mw.ankiDictionary.isVisible.return_value = True
@@ -55,7 +55,7 @@ class TestConfig(unittest.TestCase):
         refresh_anki_dict_config(config)
         mock_mw.ankiDictionary.resetConfiguration.assert_called_once()
 
-    @patch("anki_dictionary.utils.config.mw")
+    @patch("anki_dictionary.utils.config.aqt.mw")
     def test_get_addon_config_from_state(self, mock_mw):
         from __init__ import get_addon_state
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
-import json
-import unittest
-from unittest.mock import MagicMock, patch
-from pathlib import Path
-
 import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 _src = str(Path(__file__).parent.parent / "src")
 if _src not in sys.path:
@@ -14,8 +11,8 @@ if _src not in sys.path:
 
 from anki_dictionary.utils.config import (
     get_addon_config,
-    save_addon_config,
     refresh_anki_dict_config,
+    save_addon_config,
 )
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,19 +1,16 @@
-# -*- coding: utf-8 -*-
-import unittest
-from unittest.mock import MagicMock, patch
-import os
-import sqlite3
-import tempfile
-import sys
 import json
+import os
+import sys
+import tempfile
+import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from anki_dictionary.core.database import DictDB
 from anki_dictionary.core.search.query import SearchQueryBuilder
-from anki_dictionary.core.word_list_registry import WordListProvider
 from scripts.create_empty_db import create_empty_database
 
 

--- a/tests/test_dictionary_index.py
+++ b/tests/test_dictionary_index.py
@@ -1,11 +1,11 @@
-import unittest
-import requests
 import json
-import urllib.parse
-import sys
 import os
+import sys
+import unittest
+import urllib.parse
 
 import pytest
+import requests
 
 pytestmark = pytest.mark.network
 
@@ -59,7 +59,6 @@ class TestDictionaryIndex(unittest.TestCase):
         return url
 
     def _check_url(self, url):
-        import urllib.parse
         from requests.adapters import HTTPAdapter
         from urllib3.util.retry import Retry
 
@@ -109,6 +108,7 @@ class TestDictionaryIndex(unittest.TestCase):
         """Test all dictionary URLs in the index and report which ones are broken."""
         # Use a random param to bust cache just in case
         import time
+
         from requests.adapters import HTTPAdapter
         from urllib3.util.retry import Retry
 

--- a/tests/test_forvo.py
+++ b/tests/test_forvo.py
@@ -1,6 +1,7 @@
+import base64
 import unittest
 from unittest.mock import MagicMock, patch
-import base64
+
 from anki_dictionary.integrations.forvo import ForvoWorker
 
 

--- a/tests/test_forvo_integration.py
+++ b/tests/test_forvo_integration.py
@@ -1,6 +1,5 @@
-import unittest
 import os
-import time
+import unittest
 
 import pytest
 

--- a/tests/test_image_search.py
+++ b/tests/test_image_search.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import hashlib
 import os
-import re
 import ssl
 import tempfile
 import unittest
@@ -348,7 +346,7 @@ class TestLogDebug(unittest.TestCase):
                 log_debug("test message")
                 log_path = os.path.join(tmpdir, "image_search_debug.log")
                 self.assertTrue(os.path.exists(log_path))
-                with open(log_path, "r", encoding="utf-8") as f:
+                with open(log_path, encoding="utf-8") as f:
                     content = f.read()
                 self.assertIn("test message", content)
 

--- a/tests/test_issue17_disconnect_warning.py
+++ b/tests/test_issue17_disconnect_warning.py
@@ -7,12 +7,11 @@ mocks Qt so tests can run headless.
 
 from __future__ import annotations
 
+import atexit
 import sys
 import types
 import unittest
 from unittest.mock import MagicMock, patch
-
-import atexit
 
 
 class _QtMockMeta(type):

--- a/tests/test_issue18_blank_icons.py
+++ b/tests/test_issue18_blank_icons.py
@@ -6,12 +6,11 @@ tooltips, regardless of platform.  Tests run headless via Qt mocks.
 
 from __future__ import annotations
 
+import atexit
 import sys
 import types
 import unittest
 from unittest.mock import MagicMock, patch
-
-import atexit
 
 
 class _QtMockMeta(type):

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,10 +1,12 @@
-# -*- coding: utf-8 -*-
 import unittest
 from unittest.mock import MagicMock, patch
+
 from anki_dictionary.integrations.llm import (
+    LLM_DELIMITER,
     LLMWorker,
     split_llm_definitions,
-    LLM_DELIMITER,
+)
+from anki_dictionary.integrations.llm import (
     test_llm_config as _llm_config_check,
 )
 

--- a/tests/test_search_pipeline_smoke.py
+++ b/tests/test_search_pipeline_smoke.py
@@ -5,7 +5,6 @@ but mock the Qt/Anki runtime (midict).  They do not require a display server
 or a collection, so they can run as unit tests.
 """
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -15,9 +14,9 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from scripts.create_empty_db import create_empty_database
 from anki_dictionary.core.database import DictDB
 from anki_dictionary.core.search.pipeline import SearchPipeline
+from scripts.create_empty_db import create_empty_database
 
 
 @pytest.fixture

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import atexit
 import sys
 import types
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 # ---------------------------------------------------------------------------
 # Module-level mocks for Qt, Anki, and aqt BEFORE any local imports.
@@ -155,10 +154,10 @@ atexit.register(_restore_modules)
 # ---------------------------------------------------------------------------
 # Import modules under test
 # ---------------------------------------------------------------------------
-from anki_dictionary.ui.settings.settings_gui import SettingsGui
+from anki_dictionary.ui.settings.dict_groups import DictGroupEditor
 from anki_dictionary.ui.settings.dict_groups_tab import DictionaryGroupsTab
 from anki_dictionary.ui.settings.export_templates_tab import ExportTemplatesTab
-from anki_dictionary.ui.settings.dict_groups import DictGroupEditor
+from anki_dictionary.ui.settings.settings_gui import SettingsGui
 from anki_dictionary.ui.settings.templates import TemplateEditor
 
 

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,13 +1,12 @@
-import tempfile
-import unittest
 import os
 import sys
+import tempfile
+import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from anki_dictionary.ui.themes import ThemeManager, ThemeColors
+from anki_dictionary.ui.themes import ThemeColors, ThemeManager
 
 
 class TestThemes(unittest.TestCase):


### PR DESCRIPTION
- Add AGPLv3 LICENSE file (previously missing despite README claiming it)
- Expand ruff select from syntax-error tier (E9, F63, F7, F82) to F (pyflakes), I (imports), B (bugbear), UP (pyupgrade)
- Fix all 724 findings: unused imports/vars, star imports, mutable defaults, percent→f-strings, zip strict, raise-from, callable(), etc.
- Add --cov=src/ to pytest in Dagger CI, macOS workflow, and dev.py
- Update README badge/prose to point to local LICENSE file