### PR TITLE
fix: remove unused unicodedata import

### DIFF
--- a/src/anki_dictionary/utils/script_detector.py
+++ b/src/anki_dictionary/utils/script_detector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import unicodedata
 from typing import Any
 
 CJK_UNIFIED = range(0x4E00, 0x9FFF + 1)


### PR DESCRIPTION
ruff F401 was failing in CI because unicodedata was imported but never used in script_detector.py.