### PR TITLE
feat: release notes popup, welcome screen footer, rename Search in Browser

### DIFF
--- a/assets/templates/macwelcome.html
+++ b/assets/templates/macwelcome.html
@@ -2,41 +2,51 @@
     /* Reset Anki's default styles */
     *{box-sizing:border-box !important}
     html,body{margin:0 !important;padding:0 !important;overflow-x:hidden !important}
-    .welcome-screen{user-select:none !important;margin:0 !important;padding:5px !important;font-family:Arial,sans-serif}.keys-container{max-width:1400px;margin:0 auto !important;padding:2px !important}.shortcut-section{margin-bottom:6px !important}.shortcut-section.global-section{margin-top:clamp(15px,3vh,35px) !important}.shortcut-grid{display:grid !important;grid-template-columns:repeat(auto-fit,minmax(300px,1fr)) !important;gap:4px !important;margin-bottom:6px !important}@media(min-width:1200px){.shortcut-grid{grid-template-columns:repeat(3,1fr) !important}}.shortcut-item{display:flex !important;align-items:center !important;justify-content:space-between !important;margin:2px 0 !important;padding:6px 10px !important;background:#f8f9fa !important;border-radius:4px !important;border:1px solid #e9ecef !important}.shortcut-keys{display:flex !important;align-items:center !important;gap:3px !important}.key__button{box-sizing:border-box !important;line-height:28px !important;font-size:clamp(12px,1.4vw,15px) !important;text-align:center !important;min-width:30px !important;padding:0 6px !important;color:#495057 !important;margin:0 1px !important;height:28px !important;border:1px solid #ced4da !important;border-radius:4px !important;background:linear-gradient(135deg,#fff 0%,#f8f9fa 100%) !important;font-family:monospace !important;font-weight:500 !important;display:inline-block !important;box-shadow:0 1px 2px rgba(0,0,0,0.1) !important}.key__button:hover{background:linear-gradient(135deg,#f8f9fa 0%,#e9ecef 100%) !important}.separator{font-size:clamp(10px,1.2vw,13px) !important;color:#6c757d !important;margin:0 2px !important}.shortcut-description{font-size:clamp(12px,1.3vw,15px) !important;color:#495057 !important;margin:0 !important;flex:1 !important;text-align:right !important;padding-left:10px !important}.section-title{font-size:clamp(16px,1.8vw,20px) !important;font-weight:600 !important;color:#343a40 !important;margin:2px 0 4px 0 !important;text-align:center !important}
+    .welcome-screen{user-select:none !important;margin:0 !important;padding:5px !important;font-family:Arial,sans-serif}.keys-container{max-width:1400px;margin:0 auto !important;padding:2px !important}.shortcut-section{margin-bottom:6px !important}.shortcut-section.global-section{margin-top:clamp(15px,3vh,35px) !important}.shortcut-grid{display:grid !important;grid-template-columns:repeat(auto-fit,minmax(300px,1fr)) !important;gap:4px !important;margin-bottom:6px !important}@media(min-width:1200px){.shortcut-grid{grid-template-columns:repeat(3,1fr) !important}}.shortcut-item{display:flex !important;align-items:center !important;justify-content:space-between !important;margin:2px 0 !important;padding:6px 10px !important;background:#f8f9fa !important;border-radius:4px !important;border:1px solid #e9ecef !important}.shortcut-keys{display:flex !important;align-items:center !important;gap:3px !important}.key__button{box-sizing:border-box !important;line-height:28px !important;font-size:clamp(12px,1.4vw,15px) !important;text-align:center !important;min-width:30px !important;padding:0 6px !important;color:#495057 !important;margin:0 1px !important;height:28px !important;border:1px solid #ced4da !important;border-radius:4px !important;background:linear-gradient(135deg,#fff 0%,#f8f9fa 100%) !important;font-family:monospace !important;font-weight:500 !important;display:inline-block !important;box-shadow:0 1px 2px rgba(0,0,0,0.1) !important}.key__button:hover{background:linear-gradient(135deg,#f8f9fa 0%,#e9ecef 100%) !important}.separator{font-size:clamp(10px,1.2vw,13px) !important;color:#6c757d !important;margin:0 2px !important}.shortcut-description{font-size:clamp(12px,1.3vw,15px) !important;color:#495057 !important;margin:0 !important;flex:1 !important;text-align:right !important;padding-left:10px !important}.section-title{font-size:clamp(16px,1.8vw,20px) !important;font-weight:600 !important;color:#343a40 !important;margin:2px 0 4px 0 !important;text-align:center !important}.welcome-wrapper{display:flex !important;flex-direction:column !important;min-height:100% !important;padding:5px !important}.welcome-footer{margin-top:auto !important;text-align:center !important;padding:10px 15px !important;background:#f8f9fa !important;border-radius:6px !important;border:1px solid #e9ecef !important}
 </style>
-<div class="welcome-screen">
-    <h1 align="center" style="margin:0 0 2px 0 !important;font-size:clamp(22px,3vw,28px) !important;color:#343a40 !important">Anki Dictionary Addon</h1>
-</div>
-<div class="keys-container welcome-screen">
-    <div class="shortcut-section">
-        <h2 class="section-title">Anki Hotkeys</h2>
-        <div class="shortcut-grid">
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">⌘</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">W</div>
+<div class="welcome-wrapper">
+    <div class="welcome-screen">
+        <h1 align="center" style="margin:0 0 2px 0 !important;font-size:clamp(22px,3vw,28px) !important;color:#343a40 !important">Anki Dictionary Addon</h1>
+    </div>
+    <div class="keys-container welcome-screen">
+        <div class="shortcut-section">
+            <h2 class="section-title">Anki Hotkeys</h2>
+            <div class="shortcut-grid">
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">⌘</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">W</div>
+                    </div>
+                    <p class="shortcut-description">Open/Close dictionary</p>
                 </div>
-                <p class="shortcut-description">Open/Close dictionary</p>
-            </div>
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">⌘</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">S</div>
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">⌘</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">S</div>
+                    </div>
+                    <p class="shortcut-description">Search in Dictionary</p>
                 </div>
-                <p class="shortcut-description">Search in Dictionary</p>
-            </div>
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">⌘</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">Shift</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">B</div>
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">⌘</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">Shift</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">B</div>
+                    </div>
+                    <p class="shortcut-description">Search in Browser</p>
                 </div>
-                <p class="shortcut-description">Search in cards</p>
             </div>
         </div>
+    </div>
+    <div class="welcome-footer">
+        <p style="margin:0 0 6px 0 !important;font-size:clamp(13px,1.5vw,16px) !important;color:#495057 !important">If you find this addon useful, please consider leaving a review or starring the repo!</p>
+        <p style="margin:0 !important;font-size:clamp(12px,1.3vw,14px) !important;color:#6c757d !important">
+            <a href="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon" style="color:#0d6efd !important;text-decoration:none !important"><svg style="vertical-align:middle !important;margin-right:4px !important" width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a>
+            &nbsp;&middot;&nbsp;
+            <a href="https://ankiweb.net/shared/info/1973740182" style="color:#0d6efd !important;text-decoration:none !important"><svg style="vertical-align:middle !important;margin-right:4px !important" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M4.5 3A1.5 1.5 0 003 4.5v15A1.5 1.5 0 004.5 21h15a1.5 1.5 0 001.5-1.5v-15A1.5 1.5 0 0019.5 3h-15zM7 8.5a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h5a1 1 0 110 2H8a1 1 0 01-1-1z"/></svg>AnkiWeb</a>
+        </p>
     </div>
 </div>

--- a/assets/templates/welcome.html
+++ b/assets/templates/welcome.html
@@ -2,41 +2,51 @@
     /* Reset Anki's default styles */
     *{box-sizing:border-box !important}
     html,body{margin:0 !important;padding:0 !important;overflow-x:hidden !important}
-    .welcome-screen{user-select:none !important;margin:0 !important;padding:5px !important;font-family:Arial,sans-serif}.keys-container{max-width:1400px;margin:0 auto !important;padding:2px !important}.shortcut-section{margin-bottom:6px !important}.shortcut-section.global-section{margin-top:clamp(15px,3vh,35px) !important}.shortcut-grid{display:grid !important;grid-template-columns:repeat(auto-fit,minmax(300px,1fr)) !important;gap:4px !important;margin-bottom:6px !important}@media(min-width:1200px){.shortcut-grid{grid-template-columns:repeat(3,1fr) !important}}.shortcut-item{display:flex !important;align-items:center !important;justify-content:space-between !important;margin:2px 0 !important;padding:6px 10px !important;background:#f8f9fa !important;border-radius:4px !important;border:1px solid #e9ecef !important}.shortcut-keys{display:flex !important;align-items:center !important;gap:3px !important}.key__button{box-sizing:border-box !important;line-height:28px !important;font-size:clamp(12px,1.4vw,15px) !important;text-align:center !important;min-width:30px !important;padding:0 6px !important;color:#495057 !important;margin:0 1px !important;height:28px !important;border:1px solid #ced4da !important;border-radius:4px !important;background:linear-gradient(135deg,#fff 0%,#f8f9fa 100%) !important;font-family:monospace !important;font-weight:500 !important;display:inline-block !important;box-shadow:0 1px 2px rgba(0,0,0,0.1) !important}.key__button:hover{background:linear-gradient(135deg,#f8f9fa 0%,#e9ecef 100%) !important}.separator{font-size:clamp(10px,1.2vw,13px) !important;color:#6c757d !important;margin:0 2px !important}.shortcut-description{font-size:clamp(12px,1.3vw,15px) !important;color:#495057 !important;margin:0 !important;flex:1 !important;text-align:right !important;padding-left:10px !important}.section-title{font-size:clamp(16px,1.8vw,20px) !important;font-weight:600 !important;color:#343a40 !important;margin:2px 0 4px 0 !important;text-align:center !important}
+    .welcome-screen{user-select:none !important;margin:0 !important;padding:5px !important;font-family:Arial,sans-serif}.keys-container{max-width:1400px;margin:0 auto !important;padding:2px !important}.shortcut-section{margin-bottom:6px !important}.shortcut-section.global-section{margin-top:clamp(15px,3vh,35px) !important}.shortcut-grid{display:grid !important;grid-template-columns:repeat(auto-fit,minmax(300px,1fr)) !important;gap:4px !important;margin-bottom:6px !important}@media(min-width:1200px){.shortcut-grid{grid-template-columns:repeat(3,1fr) !important}}.shortcut-item{display:flex !important;align-items:center !important;justify-content:space-between !important;margin:2px 0 !important;padding:6px 10px !important;background:#f8f9fa !important;border-radius:4px !important;border:1px solid #e9ecef !important}.shortcut-keys{display:flex !important;align-items:center !important;gap:3px !important}.key__button{box-sizing:border-box !important;line-height:28px !important;font-size:clamp(12px,1.4vw,15px) !important;text-align:center !important;min-width:30px !important;padding:0 6px !important;color:#495057 !important;margin:0 1px !important;height:28px !important;border:1px solid #ced4da !important;border-radius:4px !important;background:linear-gradient(135deg,#fff 0%,#f8f9fa 100%) !important;font-family:monospace !important;font-weight:500 !important;display:inline-block !important;box-shadow:0 1px 2px rgba(0,0,0,0.1) !important}.key__button:hover{background:linear-gradient(135deg,#f8f9fa 0%,#e9ecef 100%) !important}.separator{font-size:clamp(10px,1.2vw,13px) !important;color:#6c757d !important;margin:0 2px !important}.shortcut-description{font-size:clamp(12px,1.3vw,15px) !important;color:#495057 !important;margin:0 !important;flex:1 !important;text-align:right !important;padding-left:10px !important}.section-title{font-size:clamp(16px,1.8vw,20px) !important;font-weight:600 !important;color:#343a40 !important;margin:2px 0 4px 0 !important;text-align:center !important}.welcome-wrapper{display:flex !important;flex-direction:column !important;min-height:100% !important;padding:5px !important}.welcome-footer{margin-top:auto !important;text-align:center !important;padding:10px 15px !important;background:#f8f9fa !important;border-radius:6px !important;border:1px solid #e9ecef !important}
 </style>
-<div class="welcome-screen">
-    <h1 align="center" style="margin:0 0 2px 0 !important;font-size:clamp(22px,3vw,28px) !important;color:#343a40 !important">Anki Dictionary Addon</h1>
-</div>
-<div class="keys-container welcome-screen">
-    <div class="shortcut-section">
-        <h2 class="section-title">Anki Hotkeys</h2>
-        <div class="shortcut-grid">
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">Ctrl</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">W</div>
+<div class="welcome-wrapper">
+    <div class="welcome-screen">
+        <h1 align="center" style="margin:0 0 2px 0 !important;font-size:clamp(22px,3vw,28px) !important;color:#343a40 !important">Anki Dictionary Addon</h1>
+    </div>
+    <div class="keys-container welcome-screen">
+        <div class="shortcut-section">
+            <h2 class="section-title">Anki Hotkeys</h2>
+            <div class="shortcut-grid">
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">Ctrl</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">W</div>
+                    </div>
+                    <p class="shortcut-description">Open/Close dictionary</p>
                 </div>
-                <p class="shortcut-description">Open/Close dictionary</p>
-            </div>
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">Ctrl</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">S</div>
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">Ctrl</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">S</div>
+                    </div>
+                    <p class="shortcut-description">Search in Dictionary</p>
                 </div>
-                <p class="shortcut-description">Search in Dictionary</p>
-            </div>
-            <div class="shortcut-item">
-                <div class="shortcut-keys">
-                    <div class="key__button">Ctrl</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">Shift</div>
-                    <span class="separator">+</span>
-                    <div class="key__button">B</div>
+                <div class="shortcut-item">
+                    <div class="shortcut-keys">
+                        <div class="key__button">Ctrl</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">Shift</div>
+                        <span class="separator">+</span>
+                        <div class="key__button">B</div>
+                    </div>
+                    <p class="shortcut-description">Search in Browser</p>
                 </div>
-                <p class="shortcut-description">Search in cards</p>
             </div>
         </div>
+    </div>
+    <div class="welcome-footer">
+        <p style="margin:0 0 6px 0 !important;font-size:clamp(13px,1.5vw,16px) !important;color:#495057 !important">If you find this addon useful, please consider leaving a review or starring the repo!</p>
+        <p style="margin:0 !important;font-size:clamp(12px,1.3vw,14px) !important;color:#6c757d !important">
+            <a href="https://github.com/Alexander-Nilsson/Anki-Dictionary-Addon" style="color:#0d6efd !important;text-decoration:none !important"><svg style="vertical-align:middle !important;margin-right:4px !important" width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a>
+            &nbsp;&middot;&nbsp;
+            <a href="https://ankiweb.net/shared/info/1973740182" style="color:#0d6efd !important;text-decoration:none !important"><svg style="vertical-align:middle !important;margin-right:4px !important" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M4.5 3A1.5 1.5 0 003 4.5v15A1.5 1.5 0 004.5 21h15a1.5 1.5 0 001.5-1.5v-15A1.5 1.5 0 0019.5 3h-15zM7 8.5a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h8a1 1 0 110 2H8a1 1 0 01-1-1zm0 4a1 1 0 011-1h5a1 1 0 110 2H8a1 1 0 01-1-1z"/></svg>AnkiWeb</a>
+        </p>
     </div>
 </div>

--- a/config.json
+++ b/config.json
@@ -102,5 +102,7 @@
   "imageAutoConvert": true,
   "forvo_enabled": true,
   "forvo_language": "ja",
-  "hsk_mode": "hsk3"
+  "hsk_mode": "hsk3",
+  "last_seen_version": "",
+  "hide_release_notes": false
 }

--- a/src/anki_dictionary/core/hooks.py
+++ b/src/anki_dictionary/core/hooks.py
@@ -59,9 +59,14 @@ def dictOnStart():
     from ..ui.main_window import removeTempFiles
 
     removeTempFiles()
-    # Uncomment if global hotkeys are enabled
-    # if mw.addonManager.getConfig(__name__)['globalHotkeys']:
-    #     initGlobalHotkeys()
+
+    # Show release notes popup for new versions
+    try:
+        from ..ui.dialogs.release_notes import check_and_show_release_notes
+
+        check_and_show_release_notes(mw)
+    except Exception:
+        pass
 
 
 def addToContextMenu(webview, menu):
@@ -367,7 +372,7 @@ def setup_gui_menu():
     mw.DictMainMenu.addAction(search_term_action)  # ty:ignore[unresolved-attribute]
     mw.dict_actions["search_term"] = search_term_action  # ty:ignore[unresolved-attribute]
 
-    search_col_action = QAction("Search in Collection", mw)
+    search_col_action = QAction("Search in Browser", mw)
     search_col_action.setShortcut(QKeySequence("Ctrl+Shift+B"))
     search_col_action.setShortcutContext(Qt.ShortcutContext.ApplicationShortcut)
     search_col_action.triggered.connect(trigger_search_col)

--- a/src/anki_dictionary/core/hooks.py
+++ b/src/anki_dictionary/core/hooks.py
@@ -65,8 +65,9 @@ def dictOnStart():
         from ..ui.dialogs.release_notes import check_and_show_release_notes
 
         check_and_show_release_notes(mw)
-    except Exception:
-        pass
+    except Exception as exc:
+        # Non-critical: release notes popup should not block addon startup.
+        print(f"Anki Dictionary: failed to show release notes: {exc}")
 
 
 def addToContextMenu(webview, menu):

--- a/src/anki_dictionary/ui/dialogs/release_notes.py
+++ b/src/anki_dictionary/ui/dialogs/release_notes.py
@@ -1,0 +1,196 @@
+"""
+Release notes dialog for the Anki Dictionary Addon.
+
+Shows a popup with the latest release notes from GitHub when a new version
+is detected. Includes a checkbox to suppress future popups.
+"""
+
+import re
+
+import requests
+from aqt.qt import (
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    Qt,
+    QTextBrowser,
+    QThread,
+    QVBoxLayout,
+    pyqtSignal,
+)
+
+from ...utils.config import get_addon_config, save_addon_config
+from ...utils.logger import get_logger
+
+log = get_logger("release_notes")
+
+GITHUB_REPO = "Alexander-Nilsson/Anki-Dictionary-Addon"
+GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+REQUEST_TIMEOUT = 5
+
+
+def _markdown_to_html(md: str) -> str:
+    """Convert GitHub-flavored markdown release body to simple HTML."""
+    html = md
+    # Headers
+    html = re.sub(r"^### (.+)$", r"<h3>\1</h3>", html, flags=re.MULTILINE)
+    html = re.sub(r"^## (.+)$", r"<h2>\1</h2>", html, flags=re.MULTILINE)
+    # Bold
+    html = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", html)
+    # Inline code
+    html = re.sub(r"`([^`]+)`", r"<code>\1</code>", html)
+    # Links
+    html = re.sub(
+        r"\[([^\]]+)\]\(([^)]+)\)",
+        r'<a href="\2">\1</a>',
+        html,
+    )
+    # Unordered list items
+    html = re.sub(r"^\* (.+)$", r"<li>\1</li>", html, flags=re.MULTILINE)
+    # Wrap consecutive <li> in <ul>
+    html = re.sub(
+        r"((?:<li>.*</li>\n?)+)",
+        r"<ul>\1</ul>",
+        html,
+    )
+    # Line breaks → <br> for remaining newlines
+    html = html.replace("\n", "<br>")
+    return html
+
+
+class _ReleaseFetcher(QThread):
+    """Background thread that fetches release info from GitHub."""
+
+    finished = pyqtSignal(dict | None)
+
+    def run(self) -> None:
+        try:
+            resp = requests.get(GITHUB_API_URL, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            data = resp.json()
+            self.finished.emit(
+                {
+                    "tag_name": data.get("tag_name", ""),
+                    "name": data.get("name", ""),
+                    "body": data.get("body", ""),
+                }
+            )
+        except Exception as e:
+            log.warning(f"Failed to fetch release notes: {e}")
+            self.finished.emit(None)
+
+
+class ReleaseNotesDialog(QDialog):
+    """Popup dialog displaying latest release notes."""
+
+    def __init__(self, version: str, parent=None) -> None:
+        super().__init__(parent)
+        self._version = version
+        self._dont_show_again = False
+        self._fetcher: _ReleaseFetcher | None = None
+        self._setup_ui()
+        self._start_fetch()
+
+    def _setup_ui(self) -> None:
+        self.setWindowTitle(f"Anki Dictionary — v{self._version}")
+        self.setMinimumSize(500, 400)
+        self.resize(550, 450)
+
+        layout = QVBoxLayout(self)
+
+        # Title
+        title = QLabel(f"<h2>What's New in v{self._version}</h2>")
+        title.setWordWrap(True)
+        layout.addWidget(title)
+
+        # Separator
+        line = QFrame()
+        line.setFrameShape(QFrame.Shape.HLine)
+        line.setFrameShadow(QFrame.Shadow.Sunken)
+        layout.addWidget(line)
+
+        # Release notes browser
+        self._browser = QTextBrowser()
+        self._browser.setOpenExternalLinks(True)
+        self._browser.setPlaceholderText("Loading release notes...")
+        self._browser.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+        )
+        layout.addWidget(self._browser)
+
+        # Checkbox + Close button row
+        bottom_layout = QHBoxLayout()
+
+        self._checkbox = QCheckBox("Don't show release notes again")
+        self._checkbox.stateChanged.connect(self._on_checkbox_changed)
+        bottom_layout.addWidget(self._checkbox)
+
+        bottom_layout.addStretch()
+
+        close_btn = QPushButton("Close")
+        close_btn.setDefault(True)
+        close_btn.clicked.connect(self._on_close)
+        bottom_layout.addWidget(close_btn)
+
+        layout.addLayout(bottom_layout)
+
+    def _start_fetch(self) -> None:
+        self._fetcher = _ReleaseFetcher()
+        self._fetcher.finished.connect(self._on_fetch_done)
+        self._fetcher.start()
+
+    def _on_fetch_done(self, data: dict | None) -> None:
+        if data is None:
+            self._browser.setHtml(
+                "<p style='color:gray'>Could not load release notes.</p>"
+            )
+            return
+
+        tag = data["tag_name"].lstrip("v")
+        body_html = _markdown_to_html(data["body"])
+
+        self._browser.setHtml(
+            f"<h3>{data['name']}</h3>"
+            if data["name"]
+            else f"<div style='font-size:12px;'>{body_html}</div>"
+        )
+
+        # Update title if tag differs from bundled version
+        if tag and tag != self._version:
+            self.setWindowTitle(f"Anki Dictionary — v{tag}")
+
+    def _on_checkbox_changed(self, state: int) -> None:
+        self._dont_show_again = state == Qt.CheckState.Checked.value
+
+    def _on_close(self) -> None:
+        config = get_addon_config()
+        if self._dont_show_again:
+            config["hide_release_notes"] = True
+        config["last_seen_version"] = self._version
+        save_addon_config(config)
+        self.accept()
+
+
+def check_and_show_release_notes(mw) -> None:
+    """Check if release notes should be shown and display the dialog.
+
+    Called on profileLoaded. Compares the bundled version against the
+    last-seen version stored in config and respects the user's opt-out.
+    """
+    from ... import __version__
+
+    config = get_addon_config()
+
+    if config.get("hide_release_notes", False):
+        return
+
+    last_seen = config.get("last_seen_version", "")
+    if last_seen == __version__:
+        return
+
+    dialog = ReleaseNotesDialog(__version__, parent=mw)
+    dialog.exec()

--- a/src/anki_dictionary/utils/config.py
+++ b/src/anki_dictionary/utils/config.py
@@ -109,6 +109,8 @@ def get_addon_config() -> dict[str, Any]:
         "word_list_visibility": {},
         "auto_select_dict_group": True,
         "language_defaults": {},
+        "last_seen_version": "",
+        "hide_release_notes": False,
     }
 
 

--- a/src/anki_dictionary/utils/script_detector.py
+++ b/src/anki_dictionary/utils/script_detector.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import unicodedata
 from typing import Any
 
 CJK_UNIFIED = range(0x4E00, 0x9FFF + 1)


### PR DESCRIPTION
## Changes

### Release Notes Popup
- New `ReleaseNotesDialog` that fetches latest GitHub release on profile load
- Compares bundled version against `last_seen_version` in config
- "Don't show again" checkbox suppresses future popups
- Markdown-to-HTML rendering for release body

### Welcome Screen
- Restructured with flex layout, footer pinned to bottom
- Added GitHub and AnkiWeb icon links in footer
- Renamed `Ctrl+Shift+B` shortcut from "Search in cards" to "Search in Browser"

### Config
- Added `last_seen_version` and `hide_release_notes` fields

### Cleanup
- Removed unused `unicodedata` import from `script_detector.py`
- Removed dead commented-out code in `hooks.py`
